### PR TITLE
Fix zb failing to build on windows due to misconfigured package name

### DIFF
--- a/internal/frontend/path_eval_windows.go
+++ b/internal/frontend/path_eval_windows.go
@@ -1,7 +1,7 @@
 // Copyright 2024 The zb Authors
 // SPDX-License-Identifier: MIT
 
-package zb
+package frontend
 
 import "io/fs"
 


### PR DESCRIPTION
I was getting an error while trying to compile zb on windows, it seems like this package was misconfigured.

Without this patch, go wasn't able to compile the project for windows returning this error:

```
go build
derivation.go:17:2: found packages frontend (derivation_eval.go) and zb (path_eval_windows.go) in C:\zb\internal\frontend
```

After changing this, I was able to generate the .exe for zb