### PR TITLE
Fix installer 'to_abs' to not adjust empty string

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -11,7 +11,11 @@ log() {
   echo "$@" >&2
 }
 to_abs() {
-  cd -- "$1" &> /dev/null && pwd
+  if [[ -z "$1" ]]; then
+    echo ""
+  else
+    cd -- "$1" &> /dev/null && pwd
+  fi
 }
 
 if [[ "${ZB_STORE_DIR:-/opt/zb/store}" != /opt/zb/store ]]; then


### PR DESCRIPTION
Empty string implies a "don't do this", eg:

```
if [[ -z "$bin_dir" ]]; then
```

`to_abs` was changing this to the current directory.

Learned something new in that bash `cd -- ""` changes to current directory and in fish it throws an error