### PR TITLE
Split NixOS packaging into separate files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,16 @@
           inherit system;
         };
 
-        version = "0.1.0-rc2";
+        inherit (pkgs.lib.attrsets) optionalAttrs;
 
         go = pkgs.go_1_24;
         buildGoModule = pkgs.buildGo124Module;
+
+        zbPackage = pkgs.callPackage ./package.nix {
+          inherit buildGoModule;
+        };
+
+        installerPackage = pkgs.callPackage ./installer {};
       in
       {
         devShells.default = pkgs.mkShellNoCC {
@@ -45,135 +51,27 @@
           hardeningDisable = [ "fortify" ];
         };
 
-        packages.default = buildGoModule {
-          pname = "zb";
-          version = version;
-
-          ldflags = [
-            "-s -w -X main.zbVersion=${version}"
-          ];
-
-          src = ./.;
-
-          vendorHash = "sha256-B1DROm8KMfKPupJ7d75Oh8QcJae3UyWwVm8EhnNMayA=";
-        };
-
-        packages.installer = pkgs.stdenv.mkDerivation {
-          name = "zb-installer";
-          version = version;
-
-          dontFixup = true;
-
-          src = pkgs.fetchurl {
-            url = "https://github.com/256lights/zb/releases/download/v0.1.0-rc2/zb-v0.1.0-rc2-x86_64-unknown-linux.tar.bz2";
-            sha256 = "sha256-wFvYWrPc7t3dzX7vRdXuhBLWJ5ehV2n8A/CxOWhXln0=";
-          };
-
-          installPhase = ''
-            mkdir -p $out
-            cp -a --reflink=auto . $out
-          '';
+        packages = {
+          default = zbPackage;
+        } // optionalAttrs (builtins.elem system installerPackage.meta.platforms) {
+          installer = installerPackage;
         };
       }
     )
     // {
-      nixosModules.default =
-        {
-          pkgs,
-          lib,
-          config,
-          ...
-        }:
+      nixosModules.default = {pkgs, lib, ... }:
         let
-          zb = self.packages.${pkgs.system}.default;
-          zbInstaller = self.packages.${pkgs.system}.installer;
+          # Slightly higher than option defaults (1500),
+          # but lower than lib.mkDefault (1000).
+          mkDefault = lib.mkOverride 1400;
+
+          selfPackages = self.packages.${pkgs.hostSystem.system};
         in
         {
-          options.zb = {
-            buildGroup = lib.mkOption {
-              type = lib.types.str;
-              default = "zbld";
-              description = "Group Name for the build users";
-            };
-            buildGid = lib.mkOption {
-              type = lib.types.int;
-              default = 256000;
-              description = "Group ID for the build users";
-            };
-            firstBuildUid = lib.mkOption {
-              type = lib.types.int;
-              default = 256001;
-              description = "First user ID for the build users, will increment for each";
-            };
-            userCount = lib.mkOption {
-              type = lib.types.int;
-              default = 32;
-              description = "Number of build users to create";
-            };
-          };
-
-          config = {
-            environment.systemPackages = [ zb ];
-
-            users.users = builtins.listToAttrs (
-              map (i: {
-                name = "${config.zb.buildGroup}${toString i}";
-                value = {
-                  description = "zb build user ${toString i}";
-                  uid = config.zb.firstBuildUid + (i - 1);
-                  group = config.zb.buildGroup;
-                  isSystemUser = true;
-                };
-              }) (lib.range 1 config.zb.userCount)
-            );
-
-            users.groups.${config.zb.buildGroup} = {
-              gid = config.zb.buildGid;
-              members = map (i: "${config.zb.buildGroup}${toString i}") (lib.range 1 config.zb.userCount);
-            };
-
-            systemd.services.zb-install = {
-              description = "zb Install";
-              unitConfig = {
-                ConditionPathExists = "!/opt/zb/store";
-              };
-              path = [ pkgs.bash ];
-              script = "bash ${zbInstaller}/install --bin '' --build-users-group '' --no-systemd";
-              serviceConfig = {
-                Type = "oneshot";
-              };
-            };
-
-            systemd.sockets.zb-serve = {
-              description = "zb Store Server Socket";
-              before = [ "multi-user.target" ];
-              unitConfig = {
-                RequiresMountsFor = [ "/opt/zb" ];
-              };
-              listenStreams = [ "/opt/zb/var/zb/server.sock" ];
-              wantedBy = [ "sockets.target" ];
-            };
-
-            systemd.services.zb-serve = {
-              description = "zb Store Server";
-              requires = [
-                "zb-serve.socket"
-                "zb-install.service"
-              ];
-              after = [ "zb-install.service" ];
-              unitConfig = {
-                RequiresMountsFor = [
-                  "/opt/zb/store"
-                  "/opt/zb/var"
-                  "/opt/zb/var/zb"
-                ];
-                ConditionPathIsReadWrite = "/opt/zb/var/zb";
-              };
-              serviceConfig = {
-                ExecStart = "${zb}/bin/zb serve --systemd --sandbox-path=/bin/sh=/opt/zb/store/hpsxd175dzfmjrg27pvvin3nzv3yi61k-busybox-1.36.1/bin/sh --implicit-system-dep=/bin/sh --build-users-group=${config.zb.buildGroup}";
-                KillMode = "mixed";
-              };
-            };
+          imports = [ ./module.nix ];
+          config.zb = {
+            package = mkDefault selfPackages.default;
+            installerPackage = mkDefault selfPackages.installer;
           };
         };
     };

--- a/installer/default.nix
+++ b/installer/default.nix
@@ -1,0 +1,46 @@
+# Copyright 2025 The zb Authors
+# SPDX-License-Identifier: MIT
+
+{ stdenvNoCC
+, fetchurl
+, lib
+}:
+
+let
+  version = "0.1.0-rc2";
+
+  fetchurlArgs = {
+    "x86_64-linux" = {
+      url = "https://github.com/256lights/zb/releases/download/v${version}/zb-v${version}-x86_64-unknown-linux.tar.bz2";
+      hash = "sha256:c05bd85ab3dceeddddcd7eef45d5ee8412d62797a15769fc03f0b1396857967d";
+    };
+
+    "aarch64-darwin" = {
+      url = "https://github.com/256lights/zb/releases/download/v${version}/zb-v${version}-aarch64-apple-macos.tar.bz2";
+      hash = "sha256:7a351d46c4302adacb52e9880d0009183d91e04716aab1e66af1eba60b8d09e4";
+    };
+  };
+in
+
+stdenvNoCC.mkDerivation {
+  pname = "zb-installer";
+  inherit version;
+  src = fetchurl fetchurlArgs.${stdenvNoCC.targetPlatform.system};
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+  installPhase = ''
+    mkdir -p $out
+    cp -a --reflink=auto . $out
+  '';
+
+  meta = {
+    description = "The zb installer";
+    homepage = "https://zb.256lights.llc/";
+    downloadPage = "https://github.com/256lights/zb/releases/latest";
+    platforms = builtins.attrNames fetchurlArgs;
+    license = lib.licenses.mit;
+    sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+  };
+}

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,105 @@
+# Copyright 2025 The zb Authors
+# SPDX-License-Identifier: MIT
+
+{ pkgs, lib, config, ...  }:
+
+let
+  cfg = config.zb;
+in
+{
+  options.zb = {
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The zb package to use";
+    };
+    installerPackage = lib.mkOption {
+      type = lib.types.package;
+      description = "The zb installer package to use";
+    };
+
+    buildGroup = lib.mkOption {
+      type = lib.types.str;
+      default = "zbld";
+      description = "Group Name for the build users";
+    };
+    buildGid = lib.mkOption {
+      type = lib.types.int;
+      default = 256000;
+      description = "Group ID for the build users";
+    };
+    firstBuildUid = lib.mkOption {
+      type = lib.types.int;
+      default = 256001;
+      description = "First user ID for the build users, will increment for each";
+    };
+    userCount = lib.mkOption {
+      type = lib.types.int;
+      default = 32;
+      description = "Number of build users to create";
+    };
+  };
+
+  config = {
+    environment.systemPackages = [ cfg.package ];
+
+    users.users = builtins.listToAttrs (
+      map (i: {
+        name = "${cfg.buildGroup}${toString i}";
+        value = {
+          description = "zb build user ${toString i}";
+          uid = cfg.firstBuildUid + (i - 1);
+          group = cfg.buildGroup;
+          isSystemUser = true;
+        };
+      }) (lib.range 1 cfg.userCount)
+    );
+
+    users.groups.${cfg.buildGroup} = {
+      gid = cfg.buildGid;
+      members = map (i: "${cfg.buildGroup}${toString i}") (lib.range 1 cfg.userCount);
+    };
+
+    systemd.services.zb-install = {
+      description = "zb Install";
+      unitConfig = {
+        ConditionPathExists = "!/opt/zb/store";
+      };
+      path = [ pkgs.bash ];
+      script = "bash ${cfg.installerPackage}/install --bin '' --build-users-group '' --no-systemd";
+      serviceConfig = {
+        Type = "oneshot";
+      };
+    };
+
+    systemd.sockets.zb-serve = {
+      description = "zb Store Server Socket";
+      before = [ "multi-user.target" ];
+      unitConfig = {
+        RequiresMountsFor = [ "/opt/zb" ];
+      };
+      listenStreams = [ "/opt/zb/var/zb/server.sock" ];
+      wantedBy = [ "sockets.target" ];
+    };
+
+    systemd.services.zb-serve = {
+      description = "zb Store Server";
+      requires = [
+        "zb-serve.socket"
+        "zb-install.service"
+      ];
+      after = [ "zb-install.service" ];
+      unitConfig = {
+        RequiresMountsFor = [
+          "/opt/zb/store"
+          "/opt/zb/var"
+          "/opt/zb/var/zb"
+        ];
+        ConditionPathIsReadWrite = "/opt/zb/var/zb";
+      };
+      serviceConfig = {
+        ExecStart = "${zb}/bin/zb serve --systemd --sandbox-path=/bin/sh=/opt/zb/store/hpsxd175dzfmjrg27pvvin3nzv3yi61k-busybox-1.36.1/bin/sh --implicit-system-dep=/bin/sh --build-users-group=${cfg.buildGroup}";
+        KillMode = "mixed";
+      };
+    };
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,27 @@
+{ buildGoModule
+, lib
+}:
+
+let
+  version = "0.1.0-rc2";
+in
+
+buildGoModule {
+  pname = "zb";
+  version = version;
+
+  ldflags = [
+    "-s -w -X main.zbVersion=${version}"
+  ];
+
+  src = ./.;
+
+  vendorHash = "sha256-B1DROm8KMfKPupJ7d75Oh8QcJae3UyWwVm8EhnNMayA=";
+
+  meta = {
+    description = "An experiment in hermetic, reproducible build systems.";
+    homepage = "https://zb.256lights.llc/";
+    downloadPage = "https://github.com/256lights/zb/releases/latest";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
One for each of:
- zb package
- installer package
- NixOS module

Added `package` and `installerPackage` module options to allow flake to add in packages while keeping files separate.