### PR TITLE
Schedule realization work using reverse dependency graph

### DIFF
--- a/internal/backend/graph.go
+++ b/internal/backend/graph.go
@@ -13,48 +13,104 @@ import (
 	"zb.256lights.llc/pkg/zbstore"
 )
 
-// findMultiOutputDerivationsInBuild identifies the set of derivations required to build the want set
-// that have more than one used output.
-func findMultiOutputDerivationsInBuild(derivations map[zbstore.Path]*zbstore.Derivation, want sets.Set[zbstore.OutputReference]) (map[zbstore.Path]sets.Set[string], error) {
+// dependencyGraph stores indices of a set of derivations that are useful for realization.
+type dependencyGraph struct {
+	// nodes is a map of .drv file path to [*dependencyGraphNode].
+	nodes map[zbstore.Path]*dependencyGraphNode
+	// roots is the set of .drv files that have no input derivations.
+	roots sets.Set[zbstore.Path]
+}
+
+// get gets or creates a node in graph.nodes for the given path.
+// If created, then the node's derivation is set to drv.
+func (graph *dependencyGraph) get(path zbstore.Path, drv *zbstore.Derivation) *dependencyGraphNode {
+	node := graph.nodes[path]
+	if node == nil {
+		node = &dependencyGraphNode{derivation: drv}
+		graph.nodes[path] = node
+	}
+	return node
+}
+
+// dependencyGraphNode stores auxiliary information about a [*zbstore.Derivation].
+type dependencyGraphNode struct {
+	derivation *zbstore.Derivation
+
+	// dependents is the set of paths of derivations that depend on this one.
+	dependents sets.Set[zbstore.Path]
+	// usedOutputs is the set of output names that a build must have realizations for.
+	usedOutputs sets.Set[unique.Handle[string]]
+}
+
+// analyze produces a [dependencyGraph] for the given set of desired outputs.
+func analyze(derivations map[zbstore.Path]*zbstore.Derivation, want sets.Set[zbstore.OutputReference]) (*dependencyGraph, error) {
+	result := &dependencyGraph{
+		roots: make(sets.Set[zbstore.Path]),
+		nodes: make(map[zbstore.Path]*dependencyGraphNode),
+	}
+
 	drvHashes := make(map[zbstore.Path]hashKey)
 	used := make(map[hashKey]sets.Set[unique.Handle[string]])
-	drvPathMap := make(map[hashKey]sets.Set[zbstore.Path])
 	stack := slices.Collect(want.All())
 	for len(stack) > 0 {
-		curr := xslices.Last(stack)
+		ref := xslices.Last(stack)
 		stack = xslices.Pop(stack, 1)
+		if _, hashed := drvHashes[ref.DrvPath]; hashed {
+			// Already visited this derivation.
+			continue
+		}
 
-		drv := derivations[curr.DrvPath]
+		drv := derivations[ref.DrvPath]
 		if drv == nil {
-			return nil, fmt.Errorf("%s: unknown derivation", curr.DrvPath)
+			return result, fmt.Errorf("analyze %s: unknown derivation", ref.DrvPath)
 		}
+		// Ensure we have a node for every derivation.
+		result.get(ref.DrvPath, drv)
 
-		hk, hashed := drvHashes[curr.DrvPath]
-		if !hashed {
-			h, err := pseudoHashDrv(drv)
-			if err != nil {
-				return nil, fmt.Errorf("%s: %v", curr.DrvPath, err)
-			}
-			hk = makeHashKey(h)
-			drvHashes[curr.DrvPath] = hk
+		h, err := pseudoHashDrv(drv)
+		if err != nil {
+			return nil, fmt.Errorf("analyze %s: %v", ref.DrvPath, err)
 		}
-		if used[hk].Len() == 0 {
-			used[hk] = make(sets.Set[unique.Handle[string]])
-			stack = slices.AppendSeq(stack, derivations[curr.DrvPath].InputDerivationOutputs())
-		}
-		addToMultiMap(used, hk, unique.Make(curr.OutputName))
-		addToMultiMap(drvPathMap, hk, curr.DrvPath)
-	}
-	result := make(map[zbstore.Path]sets.Set[string])
-	for drvHash, usedOutputNames := range used {
-		if usedOutputNames.Len() > 1 {
-			for drvPath := range drvPathMap[drvHash].All() {
-				for outputName := range usedOutputNames.All() {
-					addToMultiMap(result, drvPath, outputName.Value())
+		hk := makeHashKey(h)
+		drvHashes[ref.DrvPath] = hk
+		addToMultiMap(used, hk, unique.Make(ref.OutputName))
+
+		// Fill in reverse dependency graph.
+		if len(drv.InputDerivations) == 0 {
+			result.roots.Add(ref.DrvPath)
+		} else {
+			for inputDrvPath, outputNames := range drv.InputDerivations {
+				inputNode := result.get(inputDrvPath, derivations[inputDrvPath])
+				if inputNode.dependents == nil {
+					inputNode.dependents = make(sets.Set[zbstore.Path])
+				}
+				inputNode.dependents.Add(ref.DrvPath)
+				for outputName := range outputNames.Values() {
+					stack = append(stack, zbstore.OutputReference{
+						DrvPath:    inputDrvPath,
+						OutputName: outputName,
+					})
 				}
 			}
 		}
 	}
+
+	// Fill in the usedOutputs as a separate pass.
+	// If we had multiple derivations that are structurally the same,
+	// they may use distinct output sets and we want to build the outputs.
+	//
+	// Multi-output derivations are particularly troublesome for us
+	// because if we realize they need to be built
+	// after we've already picked a realization for one of the outputs,
+	// the build can invalidate the usage of other realizations.
+	// (However, this can only occur if more than one output is used in the build.)
+	// As long as the derivation is *mostly* deterministic,
+	// then we have a good shot of being able to reuse more realizations throughout the rest of the build process
+	// because of the early cutoff optimization from content-addressing.
+	for drvPath, currentNode := range result.nodes {
+		currentNode.usedOutputs = used[drvHashes[drvPath]]
+	}
+
 	return result, nil
 }
 

--- a/internal/backend/graph_test.go
+++ b/internal/backend/graph_test.go
@@ -1,0 +1,304 @@
+// Copyright 2025 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package backend
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"unique"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"zb.256lights.llc/pkg/internal/system"
+	"zb.256lights.llc/pkg/sets"
+	"zb.256lights.llc/pkg/zbstore"
+	"zombiezen.com/go/nix"
+)
+
+func TestAnalyze(t *testing.T) {
+	tests := []struct {
+		name           string
+		derivations    []*zbstore.Derivation
+		desiredOutputs map[string]sets.Set[string]
+		want           *dependencyGraph
+	}{
+		{
+			name: "Empty",
+			want: &dependencyGraph{},
+		},
+		{
+			name: "SingleNode",
+			derivations: []*zbstore.Derivation{
+				{
+					Name:   "foo.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+			},
+			desiredOutputs: map[string]sets.Set[string]{
+				"foo.txt": sets.New("out"),
+			},
+			want: &dependencyGraph{
+				roots: sets.New[zbstore.Path]("foo.txt"),
+				nodes: map[zbstore.Path]*dependencyGraphNode{
+					"foo.txt": {
+						usedOutputs: sets.New(unique.Make("out")),
+					},
+				},
+			},
+		},
+		{
+			name: "TwoNodes",
+			derivations: []*zbstore.Derivation{
+				{
+					Name:   "foo.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "bar.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+			},
+			desiredOutputs: map[string]sets.Set[string]{
+				"foo.txt": sets.New("out"),
+				"bar.txt": sets.New("out"),
+			},
+			want: &dependencyGraph{
+				roots: sets.New[zbstore.Path]("foo.txt", "bar.txt"),
+				nodes: map[zbstore.Path]*dependencyGraphNode{
+					"foo.txt": {
+						usedOutputs: sets.New(unique.Make("out")),
+					},
+					"bar.txt": {
+						usedOutputs: sets.New(unique.Make("out")),
+					},
+				},
+			},
+		},
+		{
+			name: "TwoNodeChain",
+			derivations: []*zbstore.Derivation{
+				{
+					Name:   "foo.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "bar.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+						"foo.txt": sets.NewSorted("out"),
+					},
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+			},
+			desiredOutputs: map[string]sets.Set[string]{
+				"bar.txt": sets.New("out"),
+			},
+			want: &dependencyGraph{
+				roots: sets.New[zbstore.Path]("foo.txt"),
+				nodes: map[zbstore.Path]*dependencyGraphNode{
+					"foo.txt": {
+						dependents:  sets.New[zbstore.Path]("bar.txt"),
+						usedOutputs: sets.New(unique.Make("out")),
+					},
+					"bar.txt": {
+						usedOutputs: sets.New(unique.Make("out")),
+					},
+				},
+			},
+		},
+		{
+			name: "Hinge",
+			derivations: []*zbstore.Derivation{
+				{
+					Name:   "foo.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "bar.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "baz.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+						"foo.txt": sets.NewSorted("out"),
+						"bar.txt": sets.NewSorted("out"),
+					},
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+			},
+			desiredOutputs: map[string]sets.Set[string]{
+				"baz.txt": sets.New("out"),
+			},
+			want: &dependencyGraph{
+				roots: sets.New[zbstore.Path]("foo.txt", "bar.txt"),
+				nodes: map[zbstore.Path]*dependencyGraphNode{
+					"foo.txt": {
+						dependents:  sets.New[zbstore.Path]("baz.txt"),
+						usedOutputs: sets.New(unique.Make("out")),
+					},
+					"bar.txt": {
+						dependents:  sets.New[zbstore.Path]("baz.txt"),
+						usedOutputs: sets.New(unique.Make("out")),
+					},
+					"baz.txt": {
+						usedOutputs: sets.New(unique.Make("out")),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			derivations := make(map[zbstore.Path]*zbstore.Derivation)
+			pathForDrvName := func(name string) (zbstore.Path, error) {
+				for p := range derivations {
+					if curr, _ := p.DerivationName(); curr == name {
+						return p, nil
+					}
+				}
+				return "", fmt.Errorf("no such derivation %s", name)
+			}
+			for _, drv := range test.derivations {
+				rewrittenInputs, err := rewriteKeys(drv.InputDerivations, func(k zbstore.Path) (zbstore.Path, error) {
+					return pathForDrvName(string(k))
+				})
+				if err != nil {
+					t.Fatalf("%s: input derivations: %v", drv.Name, err)
+				}
+				drv = drv.Clone()
+				drv.InputDerivations = rewrittenInputs
+
+				_, trailer, err := drv.Export(nix.SHA256)
+				if err != nil {
+					t.Fatal(err)
+				}
+				drvPath, err := zbstore.FixedCAOutputPath(drv.Dir, drv.Name+zbstore.DerivationExt, trailer.ContentAddress, zbstore.References{
+					Others: trailer.References,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				derivations[drvPath] = drv
+			}
+
+			desiredOutputs := make(sets.Set[zbstore.OutputReference])
+			for drvName, outputNames := range test.desiredOutputs {
+				drvPath, err := pathForDrvName(drvName)
+				if err != nil {
+					t.Fatal("desired outputs:", err)
+				}
+				for name := range outputNames.All() {
+					desiredOutputs.Add(zbstore.OutputReference{
+						DrvPath:    drvPath,
+						OutputName: name,
+					})
+				}
+			}
+
+			got, err := analyze(derivations, desiredOutputs)
+			if err != nil {
+				t.Fatal("analyze:", err)
+			}
+
+			for drvPath, drv := range derivations {
+				node := got.nodes[drvPath]
+				if node == nil {
+					t.Errorf("analyze did not return a node for %s", drvPath)
+					continue
+				}
+				if node.derivation == nil {
+					t.Errorf("analysis node for %s did not set derivation", drvPath)
+				} else if node.derivation != drv {
+					t.Errorf("analysis node for %s does not match derivation", drvPath)
+				}
+			}
+
+			want := new(dependencyGraph)
+			*want = *test.want
+			want.nodes = make(map[zbstore.Path]*dependencyGraphNode)
+			for fakePath, node := range test.want.nodes {
+				drvPath, err := pathForDrvName(string(fakePath))
+				if err != nil {
+					t.Fatal("want.nodes:", err)
+				}
+				nodeClone := new(dependencyGraphNode)
+				*nodeClone = *node
+				nodeClone.dependents, err = rewriteKeys(node.dependents, func(p zbstore.Path) (zbstore.Path, error) {
+					return pathForDrvName(string(p))
+				})
+				if err != nil {
+					t.Fatal("want.nodes:", err)
+				}
+				want.nodes[drvPath] = nodeClone
+			}
+			want.roots = make(sets.Set[zbstore.Path])
+			for fakePath := range test.want.roots.All() {
+				drvPath, err := pathForDrvName(string(fakePath))
+				if err != nil {
+					t.Fatal("want.roots:", err)
+				}
+				want.roots.Add(drvPath)
+			}
+
+			diff := cmp.Diff(
+				want, got,
+				cmpopts.EquateEmpty(),
+				cmp.AllowUnexported(dependencyGraph{}),
+				cmp.AllowUnexported(dependencyGraphNode{}),
+				cmp.FilterPath(func(p cmp.Path) bool {
+					return p.Index(-2).Type() == reflect.TypeFor[dependencyGraphNode]() &&
+						p.Index(-1).(cmp.StructField).Name() == "derivation"
+				}, cmp.Ignore()),
+			)
+			if diff != "" {
+				t.Errorf("analysis (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func rewriteKeys[K1 comparable, K2 comparable, V any, M1 ~map[K1]V](m M1, f func(K1) (K2, error)) (map[K2]V, error) {
+	m2 := make(map[K2]V, len(m))
+	for k, v := range m {
+		k2, err := f(k)
+		if err != nil {
+			return nil, err
+		}
+		m2[k2] = v
+	}
+	return m2, nil
+}


### PR DESCRIPTION
Allows the full set of build outputs required to be computed upfront and unit-tested. Also makes concurrent builder execution easier to implement.

Updates #32
Updates #43