### PR TITLE
Remove store socket before listening if it exists.

### DIFF
--- a/cmd/zb/serve.go
+++ b/cmd/zb/serve.go
@@ -108,11 +108,9 @@ func (c *serveCommand) Run(ctx context.Context, g *globalConfig) error {
 	} else {
 		webHandler.staticAssets = ui.StaticAssets()
 	}
-	if _, err := os.Stat(g.StoreSocket); err == nil {
-		log.Infof(ctx, "Cleaning up existing store on %s", g.StoreSocket)
-		if err = os.Remove(g.StoreSocket); err != nil {
-			return err
-		}
+	log.Infof(ctx, "Cleaning up existing store on %s", g.StoreSocket)
+	if err = os.Remove(g.StoreSocket); err != nil && ! errors.Is(err, os.ErrNotExist) {
+		return err
 	}
 
 	var l net.Listener

--- a/cmd/zb/serve.go
+++ b/cmd/zb/serve.go
@@ -108,9 +108,11 @@ func (c *serveCommand) Run(ctx context.Context, g *globalConfig) error {
 	} else {
 		webHandler.staticAssets = ui.StaticAssets()
 	}
-	log.Infof(ctx, "Cleaning up existing store on %s", g.StoreSocket)
-	if err = os.Remove(g.StoreSocket); err != nil && ! errors.Is(err, os.ErrNotExist) {
+
+	if err := os.Remove(g.StoreSocket); err != nil && ! errors.Is(err, os.ErrNotExist) {
 		return err
+	} else if err == nil {
+		log.Infof(ctx, "Cleaned up existing socket at %s", g.StoreSocket)
 	}
 
 	var l net.Listener

--- a/cmd/zb/serve.go
+++ b/cmd/zb/serve.go
@@ -108,6 +108,12 @@ func (c *serveCommand) Run(ctx context.Context, g *globalConfig) error {
 	} else {
 		webHandler.staticAssets = ui.StaticAssets()
 	}
+	if _, err := os.Stat(g.StoreSocket); err == nil {
+		log.Infof(ctx, "Cleaning up existing store on %s", g.StoreSocket)
+		if err = os.Remove(g.StoreSocket); err != nil {
+			return err
+		}
+	}
 
 	var l net.Listener
 	if runtime.GOOS == "linux" && c.SystemdSocket {

--- a/cmd/zb/serve.go
+++ b/cmd/zb/serve.go
@@ -109,12 +109,6 @@ func (c *serveCommand) Run(ctx context.Context, g *globalConfig) error {
 		webHandler.staticAssets = ui.StaticAssets()
 	}
 
-	if err := os.Remove(g.StoreSocket); err != nil && ! errors.Is(err, os.ErrNotExist) {
-		return err
-	} else if err == nil {
-		log.Infof(ctx, "Cleaned up existing socket at %s", g.StoreSocket)
-	}
-
 	var l net.Listener
 	if runtime.GOOS == "linux" && c.SystemdSocket {
 		listeners, err := activation.Listeners()
@@ -126,6 +120,12 @@ func (c *serveCommand) Run(ctx context.Context, g *globalConfig) error {
 		}
 		l = listeners[0]
 	} else {
+		if err := os.Remove(g.StoreSocket); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		} else if err == nil {
+			log.Infof(ctx, "Cleaned up existing socket at %s", g.StoreSocket)
+		}
+
 		var err error
 		l, err = listenUnix(g.StoreSocket)
 		if err != nil {


### PR DESCRIPTION
Resolves https://github.com/256lights/zb/issues/166

## Description

While developing it's inconvenient to remove the `ZB_STORE_SOCKET` file manually after a crash, so for the sake of expedience let's just remove the socket on startup.

### Verification Steps
```sh
$ touch /opt/zb/var/zb/server.sock

$ ./serve.sh
zb: 2026/05/07 13:57:35 INFO: Cleaning up existing store on /opt/zb/var/zb/server.sock
zb: 2026/05/07 13:57:35 INFO: Listening on /opt/zb/var/zb/server.sock
```

### Pitfalls
If you run two instances of the server, then the second instance will overwrite the socket path, and when either one of those instances shutdown gracefully they will remove the current socket path.