### PR TITLE
Run `zb store object register` as target user in install script

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -201,7 +201,7 @@ done
 
 zb="$ZB_STORE_DIR/$zb_object/bin/zb"
 log "Initializing store database..."
-"$zb" store object register < "$registry"
+run_as_target_user "$zb" store object register < "$registry"
 
 if [[ -z "$bin_dir" ]]; then
   log "zb installed at $zb"


### PR DESCRIPTION
Current install instructions recommend `sudo ./install`, so most users won't encounter this bug, but I forgot to run with `sudo` and got confused. (It should work!)