### PR TITLE
Fix parsing of `serve --sandbox-path` flags

### DIFF
--- a/cmd/zb/flags.go
+++ b/cmd/zb/flags.go
@@ -132,6 +132,8 @@ func mapStringSet(dc *kong.DecodeContext, target reflect.Value) error {
 }
 
 func mapPathMap(dc *kong.DecodeContext, target reflect.Value) error {
+	sep, _ := dc.Value.Tag.GetSep("sep", '=')
+
 	tp := target.Type()
 	if tp.Kind() != reflect.Map {
 		return fmt.Errorf("%v is not a map", tp)
@@ -151,7 +153,7 @@ func mapPathMap(dc *kong.DecodeContext, target reflect.Value) error {
 		target.Set(reflect.MakeMap(tp))
 	}
 	for word := range strings.FieldsSeq(s) {
-		k, v, isMap := strings.Cut(word, string(dc.Value.Tag.Sep))
+		k, v, isMap := strings.Cut(word, string(sep))
 		if !isMap {
 			v = k
 		}

--- a/cmd/zb/flags_test.go
+++ b/cmd/zb/flags_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestMapPathMap(t *testing.T) {
+	type customOptions struct {
+		PathMap map[string]string `kong:"type=pathmap"`
+	}
+
+	tests := []struct {
+		args []string
+		want customOptions
+	}{
+		{
+			args: []string{},
+			want: customOptions{
+				PathMap: map[string]string{},
+			},
+		},
+		{
+			args: []string{"--path-map", "/bin/sh"},
+			want: customOptions{
+				PathMap: map[string]string{
+					"/bin/sh": "/bin/sh",
+				},
+			},
+		},
+		{
+			args: []string{"--path-map=/bin/sh"},
+			want: customOptions{
+				PathMap: map[string]string{
+					"/bin/sh": "/bin/sh",
+				},
+			},
+		},
+		{
+			args: []string{"--path-map", "/bin/sh=/foo/bin/sh"},
+			want: customOptions{
+				PathMap: map[string]string{
+					"/bin/sh": "/foo/bin/sh",
+				},
+			},
+		},
+		{
+			args: []string{"--path-map", "/bin/sh=/foo/bin/sh /bin/true"},
+			want: customOptions{
+				PathMap: map[string]string{
+					"/bin/sh":   "/foo/bin/sh",
+					"/bin/true": "/bin/true",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got := new(customOptions)
+		k, err := kong.New(got, kong.NamedMapper("pathmap", kong.MapperFunc(mapPathMap)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		k.Stdout = t.Output()
+		k.Stderr = t.Output()
+		k.Exit = func(int) {}
+
+		if _, err := k.Parse(test.args); err != nil {
+			t.Errorf("parse %q: %v", test.args, err)
+			continue
+		}
+
+		if diff := cmp.Diff(&test.want, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("parse %q (-want +got):\n%s", test.args, diff)
+		}
+	}
+}


### PR DESCRIPTION
Addresses regression introduced in #185. The `kong.Tag.Sep` field is not set as described in the Kong docs for maps (it always defaults to a comma). This properly uses an equals sign.

Fixes #195