### PR TITLE
Add in-memory `zbstore.Store` implementation

### DIFF
--- a/internal/storetest/fakestore.go
+++ b/internal/storetest/fakestore.go
@@ -1,0 +1,196 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package storetest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"zb.256lights.llc/pkg/sets"
+	"zb.256lights.llc/pkg/zbstore"
+	"zombiezen.com/go/nix"
+)
+
+var _ interface {
+	zbstore.BatchStore
+	zbstore.RealizationFetcher
+	zbstore.Importer
+} = (*Store)(nil)
+
+// Store is an in-memory implementation of [zbstore.BatchStore] and [zbstore.RealizationFetcher].
+// A Store is safe to use from multiple goroutines simultaneously.
+// The zero Store value is an empty store: one without objects or realizations.
+// Objects can be added with [*Store.StoreImport].
+// Realizations can be added with [*Store.AddRealization].
+type Store struct {
+	mu           sync.RWMutex
+	objects      map[zbstore.Path]*storeObject
+	realizations map[string]map[string][]*zbstore.Realization
+}
+
+// Object implements [zbstore.Store].
+func (store *Store) Object(ctx context.Context, path zbstore.Path) (zbstore.Object, error) {
+	var obj *storeObject
+	if store != nil {
+		store.mu.RLock()
+		obj = store.objects[path]
+		store.mu.RUnlock()
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("open %s: %w", path, zbstore.ErrNotFound)
+	}
+	return obj, nil
+}
+
+// ObjectBatch implements [zbstore.BatchStore].
+func (store *Store) ObjectBatch(ctx context.Context, storePaths sets.Set[zbstore.Path]) ([]zbstore.Object, error) {
+	if storePaths.Len() == 0 || store == nil {
+		return nil, nil
+	}
+
+	objects := make([]zbstore.Object, 0, storePaths.Len())
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	for path := range storePaths.All() {
+		if obj := store.objects[path]; obj != nil {
+			objects = append(objects, obj)
+		}
+	}
+	return objects, nil
+}
+
+// StoreImport implements [zbstore.Importer] by adding the objects to the store.
+func (store *Store) StoreImport(ctx context.Context, r io.Reader) error {
+	recv := &storeReceiver{store: store}
+	err := zbstore.ReceiveExport(recv, r)
+	return errors.Join(recv.error, err)
+}
+
+// FetchRealizations implements [zbstore.RealizationFetcher].
+func (store *Store) FetchRealizations(ctx context.Context, derivationHash nix.Hash) (zbstore.RealizationMap, error) {
+	result := zbstore.RealizationMap{
+		DerivationHash: derivationHash,
+	}
+	if store != nil {
+		store.mu.RLock()
+		defer store.mu.RUnlock()
+		if m := store.realizations[derivationHash.SRI()]; len(m) > 0 {
+			for outputName, realizations := range m {
+				if len(realizations) == 0 {
+					continue
+				}
+				if result.Realizations == nil {
+					result.Realizations = make(map[string][]*zbstore.Realization, len(m))
+				}
+				realizationsCopy := make([]*zbstore.Realization, 0, len(realizations))
+				for _, r := range realizations {
+					realizationsCopy = append(realizationsCopy, cloneRealization(r))
+				}
+				result.Realizations[outputName] = realizationsCopy
+			}
+		}
+	}
+	return result, nil
+}
+
+// AddRealization adds the given realization to the store.
+func (store *Store) AddRealization(ref zbstore.RealizationOutputReference, r *zbstore.Realization) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	if store.realizations == nil {
+		store.realizations = make(map[string]map[string][]*zbstore.Realization)
+	}
+	key := ref.DerivationHash.SRI()
+	m := store.realizations[key]
+	if m == nil {
+		m = make(map[string][]*zbstore.Realization)
+		store.realizations[key] = m
+	}
+	m[ref.OutputName] = append(m[ref.OutputName], cloneRealization(r))
+}
+
+type storeObject struct {
+	nar     []byte
+	trailer zbstore.ExportTrailer
+}
+
+func (obj *storeObject) WriteNAR(ctx context.Context, dst io.Writer) error {
+	_, err := dst.Write(obj.nar)
+	return err
+}
+
+func (obj *storeObject) Trailer() *zbstore.ExportTrailer {
+	return &obj.trailer
+}
+
+type storeReceiver struct {
+	store *Store
+	buf   bytes.Buffer
+	error error
+}
+
+func (s *storeReceiver) Write(p []byte) (n int, err error) {
+	return s.buf.Write(p)
+}
+
+func (s *storeReceiver) ReceiveNAR(trailer *zbstore.ExportTrailer) {
+	obj := &storeObject{
+		nar:     s.buf.Bytes(),
+		trailer: *trailer,
+	}
+	if err := zbstore.VerifyObject(context.Background(), obj, nil); err != nil {
+		s.error = errors.Join(s.error, err)
+		return
+	}
+
+	s.store.mu.Lock()
+	if s.store.objects[obj.trailer.StorePath] == nil {
+		if s.store.objects == nil {
+			s.store.objects = make(map[zbstore.Path]*storeObject)
+		}
+		obj.nar = bytes.Clone(obj.nar)
+		obj.trailer = *cloneExportTrailer(&obj.trailer)
+		s.store.objects[obj.trailer.StorePath] = obj
+	}
+	s.store.mu.Unlock()
+
+	s.buf.Reset()
+}
+
+func cloneExportTrailer(trailer *zbstore.ExportTrailer) *zbstore.ExportTrailer {
+	trailer = new(*trailer)
+	trailer.References = *trailer.References.Clone()
+	return trailer
+}
+
+func cloneRealization(r *zbstore.Realization) *zbstore.Realization {
+	rcopy := &zbstore.Realization{
+		OutputPath: r.OutputPath,
+		Signatures: make([]*zbstore.RealizationSignature, 0, len(r.Signatures)),
+	}
+	if len(r.ReferenceClasses) > 0 {
+		rcopy.ReferenceClasses = make([]*zbstore.ReferenceClass, 0, len(r.ReferenceClasses))
+		for _, rc := range r.ReferenceClasses {
+			rcopy.ReferenceClasses = append(rcopy.ReferenceClasses, new(*rc))
+		}
+	}
+	if len(r.Signatures) > 0 {
+		rcopy.Signatures = make([]*zbstore.RealizationSignature, 0, len(r.Signatures))
+		for _, sig := range r.Signatures {
+			rcopy.Signatures = append(rcopy.Signatures, &zbstore.RealizationSignature{
+				PublicKey: zbstore.RealizationPublicKey{
+					Format: sig.PublicKey.Format,
+					Data:   bytes.Clone(sig.PublicKey.Data),
+				},
+				Signature: bytes.Clone(sig.Signature),
+			})
+		}
+	}
+	return rcopy
+}

--- a/internal/storetest/fakestore_test.go
+++ b/internal/storetest/fakestore_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package storetest
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"zb.256lights.llc/pkg/internal/testcontext"
+	"zb.256lights.llc/pkg/sets"
+	"zb.256lights.llc/pkg/zbstore"
+)
+
+func TestEmptyStore(t *testing.T) {
+	ctx := testcontext.New(t)
+
+	path, err := zbstore.DefaultUnixDirectory.Object("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := new(Store)
+
+	if _, err := store.Object(ctx, path); !errors.Is(err, zbstore.ErrNotFound) {
+		t.Errorf("new(Store).Object(ctx, %s) = _, %v; want <nil>, %v", path, err, zbstore.ErrNotFound)
+	}
+}
+
+func TestStoreImport(t *testing.T) {
+	ctx := testcontext.New(t)
+
+	narContent := new(bytes.Buffer)
+	if err := SingleFileNAR(narContent, []byte("Hello, World!\n")); err != nil {
+		t.Fatal(err)
+	}
+	exportBuffer := new(bytes.Buffer)
+	exp := zbstore.NewExportWriter(exportBuffer)
+	path, ca, err := ExportSourceNAR(exp, narContent.Bytes(), SourceExportOptions{
+		Name:      "hello.txt",
+		Directory: zbstore.DefaultUnixDirectory,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := exp.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store := new(Store)
+	if err := store.StoreImport(ctx, exportBuffer); err != nil {
+		t.Error(err)
+	}
+
+	t.Run("Object", func(t *testing.T) {
+		obj, err := store.Object(ctx, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		trailer := obj.Trailer()
+		if trailer.StorePath != path {
+			t.Errorf("obj.Trailer().StorePath = %q; want %q", trailer.StorePath, path)
+		}
+		if !trailer.ContentAddress.Equal(ca) {
+			t.Errorf("obj.Trailer().ContentAddress = %v; want %v", trailer.ContentAddress, ca)
+		}
+
+		got := new(bytes.Buffer)
+		if err := obj.WriteNAR(ctx, got); err != nil {
+			t.Error("obj.WriteNAR:", err)
+		}
+		if !bytes.Equal(got.Bytes(), narContent.Bytes()) {
+			t.Error("NAR content does not match")
+		}
+	})
+
+	t.Run("ObjectBatch", func(t *testing.T) {
+		batch, err := store.ObjectBatch(ctx, sets.New(path))
+		if err != nil {
+			t.Error("ObjectBatch:", err)
+		}
+		if len(batch) != 1 {
+			t.Errorf("len(batch) == %d; want 1", len(batch))
+		}
+
+		obj := batch[0]
+		trailer := obj.Trailer()
+		if trailer.StorePath != path {
+			t.Errorf("batch[0].Trailer().StorePath = %q; want %q", trailer.StorePath, path)
+		}
+		if !trailer.ContentAddress.Equal(ca) {
+			t.Errorf("batch[0].Trailer().ContentAddress = %v; want %v", trailer.ContentAddress, ca)
+		}
+
+		got := new(bytes.Buffer)
+		if err := obj.WriteNAR(ctx, got); err != nil {
+			t.Error("batch[0].WriteNAR:", err)
+		}
+		if !bytes.Equal(got.Bytes(), narContent.Bytes()) {
+			t.Error("NAR content does not match")
+		}
+	})
+}


### PR DESCRIPTION
Adding this in preparation for testing a backend with a fallback store.

Updates #167