### PR TITLE
Allow cache directory to be set in the configuration file

### DIFF
--- a/cmd/zb/config.go
+++ b/cmd/zb/config.go
@@ -26,18 +26,22 @@ type globalConfig struct {
 	Debug             bool                            `json:"debug" kong:"help=Show debugging output."`
 	Directory         zbstore.Directory               `json:"storeDirectory" kong:"name=store,default=${default_store_dir},help=Store directory"`
 	StoreSocket       string                          `json:"storeSocket" kong:"default=${default_store_socket},help=Server socket"`
-	CacheDB           string                          `json:"cacheDB" kong:"name=cache,placeholder=path,help=Cache database"`
+	CacheDB           string                          `json:"cacheDB" kong:"name=cache,default=${cache_db},help=Cache database"`
 	AllowEnv          stringAllowList                 `json:"allowEnvironment" kong:"-"`
 	TrustedPublicKeys []*zbstore.RealizationPublicKey `json:"trustedPublicKeys" kong:"-"`
 }
 
-// defaultGlobalConfig returns a [globalConfig] populated with default values based on OS,
-// but does not reference any environment variables.
+// defaultGlobalConfig returns a [globalConfig] populated with values
+// based on OS and generic environment variables (e.g. $HOME, $XDG_CACHE_HOME, etc.).
 func defaultGlobalConfig() *globalConfig {
-	return &globalConfig{
+	g := &globalConfig{
 		Directory:   zbstore.DefaultDirectory(),
 		StoreSocket: filepath.Join(defaultVarDir(), "server.sock"),
 	}
+	if cd := cacheDir(); cd != "" {
+		g.CacheDB = filepath.Join(cd, "zb", "cache.db")
+	}
+	return g
 }
 
 // mergeEnvironment copies environment variable values to [globalConfig] fields.
@@ -52,10 +56,6 @@ func (g *globalConfig) mergeEnvironment() error {
 
 	if path := os.Getenv("ZB_STORE_SOCKET"); path != "" {
 		g.StoreSocket = path
-	}
-
-	if cd := cacheDir(); cd != "" {
-		g.CacheDB = filepath.Join(cd, "zb", "cache.db")
 	}
 
 	return nil

--- a/cmd/zb/config_test.go
+++ b/cmd/zb/config_test.go
@@ -23,7 +23,7 @@ func TestDefaultGlobalConfig(t *testing.T) {
 		t.Errorf("defaultGlobalConfig().Directory is empty")
 	}
 	if got.StoreSocket == "" {
-		t.Errorf("defaultGlobalConfig().Directory is empty")
+		t.Errorf("defaultGlobalConfig().StoreSocket is empty")
 	}
 }
 

--- a/cmd/zb/main.go
+++ b/cmd/zb/main.go
@@ -114,9 +114,11 @@ func zbKongOption() kong.Option {
 		if !yield(kong.NamedMapper("nativeStorePath", kong.MapperFunc(mapNativeStorePath))) {
 			return
 		}
+		g := defaultGlobalConfig()
 		vars := kong.Vars{
-			"default_store_dir":         string(defaultGlobalConfig().Directory),
-			"default_store_socket":      string(defaultGlobalConfig().StoreSocket),
+			"default_store_dir":         string(g.Directory),
+			"default_store_socket":      g.StoreSocket,
+			"cache_db":                  g.CacheDB,
 			"default_store_db":          filepath.Join(defaultVarDir(), "db.sqlite"),
 			"build_users_group":         defaultBuildUsersGroup,
 			"default_build_users_group": backend.DefaultBuildUsersGroup,


### PR DESCRIPTION
It was always getting set in the `*globalConfig.mergeEnvironment` phase,
so its content in the configuration file would be ignored.

Updates #162

<!-- jj-domino -->
<!-- Do not remove this comment! Everything in this section will be rewritten by jj-domino. -->

## Related Pull Requests

This pull request is part of a stack managed by [jj-domino](https://github.com/zombiezen/jj-domino):

 1. *→ this pull request ←*
 2. #214
