### PR TITLE
Fix graph iteration with roots whose dependencies are a strict superset of another root

### DIFF
--- a/internal/backend/graph.go
+++ b/internal/backend/graph.go
@@ -47,6 +47,31 @@ func (graph *dependencyGraph) iterator() *dependencyOrderIterator {
 	}
 }
 
+// transitiveDependents returns a single-use iterator over the given paths
+// and the transitive closure of all paths in the graph that depend on the given paths.
+// After iteration is finished, the paths slice will be cleared and set to length 0.
+// transitiveDependents does not guarantee ordering,
+// nor does it guarantee that it will not yield the same path more than once.
+func (graph *dependencyGraph) transitiveDependents(paths *[]zbstore.Path) iter.Seq[zbstore.Path] {
+	return func(yield func(zbstore.Path) bool) {
+		for len(*paths) > 0 {
+			curr := xslices.Last(*paths)
+			*paths = xslices.Pop(*paths, 1)
+			if !yield(curr) {
+				clear(*paths)
+				*paths = (*paths)[:0]
+				return
+			}
+			var next sets.Set[zbstore.Path]
+			if node := graph.nodes[curr]; node != nil {
+				next = node.dependents
+			}
+			*paths = slices.Grow(*paths, next.Len())
+			*paths = slices.AppendSeq(*paths, next.All())
+		}
+	}
+}
+
 // dependencyGraphNode stores auxiliary information about a [*zbstore.Derivation].
 type dependencyGraphNode struct {
 	derivation *zbstore.Derivation
@@ -162,26 +187,27 @@ func newDependencyOrderIterator(g *dependencyGraph, roots iter.Seq[zbstore.Path]
 	}
 
 	rootSet := make(sets.Set[zbstore.Path])
+	// Maintain a slice list so we can keep the order.
 	var rootList []zbstore.Path
 	for root := range roots {
-		if !rootSet.Has(root) {
+		// Guarantee that roots appear in the graph.
+		if !rootSet.Has(root) && g.nodes[root] != nil {
 			rootList = append(rootList, root)
 			rootSet.Add(root)
 		}
 	}
 
-	// Prune any roots that depend on other paths in rootSet.
+	// Depth-first search over roots.
+	finished := make(map[zbstore.Path]bool)
 	var stack []stackEntry
+	var clearStack []zbstore.Path
 	for _, root := range rootList {
 		if !rootSet.Has(root) {
-			continue
-		}
-		node := g.nodes[root]
-		if node == nil {
-			rootSet.Delete(root)
+			// Skip if we already determined the root is a dependency of another root.
 			continue
 		}
 
+		node := g.nodes[root] // Guaranteed to be non-nil above.
 		stack = slices.Grow(stack, len(node.derivation.InputDerivations))
 		for drvPath := range node.derivation.InputDerivations {
 			stack = append(stack, stackEntry{
@@ -195,9 +221,25 @@ func newDependencyOrderIterator(g *dependencyGraph, roots iter.Seq[zbstore.Path]
 
 			nextRoot := curr.fromRoot
 			if rootSet.Has(curr.path) {
+				// curr.fromRoot transitively depends on curr.path, another root.
 				rootSet.Delete(curr.fromRoot)
 				nextRoot = curr.path
+
+				node := g.nodes[curr.path]
+				clearStack = slices.Grow(clearStack, node.dependents.Len())
+				clearStack = slices.AppendSeq(clearStack, node.dependents.All())
+				for path := range g.transitiveDependents(&clearStack) {
+					delete(finished, path)
+				}
+			} else {
+				// Mark transitive dependencies of a root as visited.
+				// If a root depends on another root
+				// plus some other dependencies that the other root does not have,
+				// we want to make sure that we visit the pruned root.
+				// See issue #224 for details.
+				finished[curr.path] = true
 			}
+
 			if node := g.nodes[curr.path]; node != nil {
 				stack = slices.Grow(stack, len(node.derivation.InputDerivations))
 				for drvPath := range node.derivation.InputDerivations {
@@ -210,26 +252,6 @@ func newDependencyOrderIterator(g *dependencyGraph, roots iter.Seq[zbstore.Path]
 		}
 	}
 	rootList = xslices.Filter(rootList, rootSet.Has)
-
-	// Mark any dependencies of the roots as visited.
-	finished := make(map[zbstore.Path]bool)
-	for _, root := range rootList {
-		stack = append(stack, stackEntry{path: root})
-		for len(stack) > 0 {
-			curr := xslices.Last(stack)
-			stack = xslices.Pop(stack, 1)
-
-			if curr.path != root {
-				finished[curr.path] = true
-			}
-			if node := g.nodes[curr.path]; node != nil {
-				stack = slices.Grow(stack, len(node.derivation.InputDerivations))
-				for drvPath := range node.derivation.InputDerivations {
-					stack = append(stack, stackEntry{path: drvPath})
-				}
-			}
-		}
-	}
 
 	return &dependencyOrderIterator{
 		graph:    g,

--- a/internal/backend/graph_test.go
+++ b/internal/backend/graph_test.go
@@ -4,8 +4,12 @@
 package backend
 
 import (
+	"errors"
 	"fmt"
+	"iter"
+	"maps"
 	"reflect"
+	"slices"
 	"testing"
 	"unique"
 
@@ -183,50 +187,13 @@ func TestAnalyze(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			derivations := make(map[zbstore.Path]*zbstore.Derivation)
-			pathForDrvName := func(name string) (zbstore.Path, error) {
-				for p := range derivations {
-					if curr, _ := p.DerivationName(); curr == name {
-						return p, nil
-					}
-				}
-				return "", fmt.Errorf("no such derivation %s", name)
+			derivations, err := rewriteDerivationsForGraphTest(test.derivations)
+			if err != nil {
+				t.Fatal(err)
 			}
-			for _, drv := range test.derivations {
-				rewrittenInputs, err := rewriteKeys(drv.InputDerivations, func(k zbstore.Path) (zbstore.Path, error) {
-					return pathForDrvName(string(k))
-				})
-				if err != nil {
-					t.Fatalf("%s: input derivations: %v", drv.Name, err)
-				}
-				drv = drv.Clone()
-				drv.InputDerivations = rewrittenInputs
-
-				_, trailer, err := drv.Export(nix.SHA256)
-				if err != nil {
-					t.Fatal(err)
-				}
-				drvPath, err := zbstore.FixedCAOutputPath(drv.Dir, drv.Name+zbstore.DerivationExt, trailer.ContentAddress, zbstore.References{
-					Others: trailer.References,
-				})
-				if err != nil {
-					t.Fatal(err)
-				}
-				derivations[drvPath] = drv
-			}
-
-			desiredOutputs := make(sets.Set[zbstore.OutputReference])
-			for drvName, outputNames := range test.desiredOutputs {
-				drvPath, err := pathForDrvName(drvName)
-				if err != nil {
-					t.Fatal("desired outputs:", err)
-				}
-				for name := range outputNames.All() {
-					desiredOutputs.Add(zbstore.OutputReference{
-						DrvPath:    drvPath,
-						OutputName: name,
-					})
-				}
+			desiredOutputs, err := rewriteDesiredOutputsForGraphTest(derivations, test.desiredOutputs)
+			if err != nil {
+				t.Fatal(err)
 			}
 
 			got, err := analyze(derivations, desiredOutputs)
@@ -251,14 +218,14 @@ func TestAnalyze(t *testing.T) {
 			*want = *test.want
 			want.nodes = make(map[zbstore.Path]*dependencyGraphNode)
 			for fakePath, node := range test.want.nodes {
-				drvPath, err := pathForDrvName(string(fakePath))
+				drvPath, err := pathForDrvName(maps.Keys(derivations), string(fakePath))
 				if err != nil {
 					t.Fatal("want.nodes:", err)
 				}
 				nodeClone := new(dependencyGraphNode)
 				*nodeClone = *node
 				nodeClone.dependents, err = rewriteKeys(node.dependents, func(p zbstore.Path) (zbstore.Path, error) {
-					return pathForDrvName(string(p))
+					return pathForDrvName(maps.Keys(derivations), string(p))
 				})
 				if err != nil {
 					t.Fatal("want.nodes:", err)
@@ -267,7 +234,7 @@ func TestAnalyze(t *testing.T) {
 			}
 			want.roots = make(sets.Set[zbstore.Path])
 			for fakePath := range test.want.roots.All() {
-				drvPath, err := pathForDrvName(string(fakePath))
+				drvPath, err := pathForDrvName(maps.Keys(derivations), string(fakePath))
 				if err != nil {
 					t.Fatal("want.roots:", err)
 				}
@@ -289,6 +256,260 @@ func TestAnalyze(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewDependencyOrderIterator(t *testing.T) {
+	tests := []struct {
+		name           string
+		derivations    []*zbstore.Derivation
+		desiredOutputs map[string]sets.Set[string]
+		roots          []string
+		orderings      [][]string
+	}{
+		{
+			name:      "Empty",
+			orderings: [][]string{{}},
+		},
+		{
+			name: "TwoNodes",
+			derivations: []*zbstore.Derivation{
+				{
+					Name:   "foo.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "bar.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+			},
+			desiredOutputs: map[string]sets.Set[string]{
+				"foo.txt": sets.New("out"),
+				"bar.txt": sets.New("out"),
+			},
+			roots: []string{"foo.txt", "bar.txt"},
+			orderings: [][]string{
+				{"foo.txt", "bar.txt"},
+				{"bar.txt", "foo.txt"},
+			},
+		},
+		{
+			name: "Chain",
+			derivations: []*zbstore.Derivation{
+				{
+					Name:   "foo.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "bar.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+						"foo.txt": sets.NewSorted("out"),
+					},
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+			},
+			desiredOutputs: map[string]sets.Set[string]{
+				"foo.txt": sets.New("out"),
+				"bar.txt": sets.New("out"),
+			},
+			roots: []string{"foo.txt", "bar.txt"},
+			orderings: [][]string{
+				{"foo.txt", "bar.txt"},
+			},
+		},
+		{
+			name: "Issue224",
+			derivations: []*zbstore.Derivation{
+				{
+					Name:   "a.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "b.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "c.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+						"a.txt": sets.NewSorted("out"),
+						"b.txt": sets.NewSorted("out"),
+					},
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+				{
+					Name:   "d.txt",
+					Dir:    zbstore.DefaultUnixDirectory,
+					System: system.Current().String(),
+					InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+						"a.txt": sets.NewSorted("out"),
+						"c.txt": sets.NewSorted("out"),
+					},
+					Outputs: map[string]*zbstore.DerivationOutputType{
+						"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+					},
+				},
+			},
+			desiredOutputs: map[string]sets.Set[string]{
+				"d.txt": sets.New("out"),
+			},
+			roots: []string{"a.txt", "c.txt"},
+			orderings: [][]string{
+				{"a.txt", "c.txt", "d.txt"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			derivations, err := rewriteDerivationsForGraphTest(test.derivations)
+			if err != nil {
+				t.Fatal(err)
+			}
+			desiredOutputs, err := rewriteDesiredOutputsForGraphTest(derivations, test.desiredOutputs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			g, err := analyze(derivations, desiredOutputs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			roots := make(sets.Set[zbstore.Path], len(test.roots))
+			for _, name := range test.roots {
+				p, err := pathForDrvName(maps.Keys(derivations), name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				roots.Add(p)
+			}
+			orderings := make([][]zbstore.Path, 0, len(test.orderings))
+			for _, want := range test.orderings {
+				wantPaths := make([]zbstore.Path, 0, len(want))
+				for _, name := range want {
+					p, err := pathForDrvName(maps.Keys(derivations), name)
+					if err != nil {
+						t.Fatal(err)
+					}
+					wantPaths = append(wantPaths, p)
+				}
+				orderings = append(orderings, wantPaths)
+			}
+
+			ctx := t.Context()
+			it := newDependencyOrderIterator(g, roots.All())
+			var got []zbstore.Path
+			for {
+				p, err := it.next(ctx)
+				if err != nil {
+					if !errors.Is(err, errEndIteration) {
+						t.Error("it.next(ctx):", err)
+					}
+					break
+				}
+				got = append(got, p)
+				it.finish(p, true)
+			}
+
+			isValid := false
+			for _, want := range orderings {
+				if slices.Equal(want, got) {
+					isValid = true
+					break
+				}
+			}
+			if !isValid {
+				t.Errorf("paths (-want +got):\n%s", cmp.Diff(orderings[0], got, cmpopts.EquateEmpty()))
+			}
+		})
+	}
+}
+
+// rewriteDerivationsForGraphTest creates a map of derivations cloned from the slice
+// with each key being a full store path
+// and each input derivation rewritten to a full path.
+// rewriteDerivationsForGraphTest returns an error if the slice is not in dependency order.
+func rewriteDerivationsForGraphTest(derivations []*zbstore.Derivation) (map[zbstore.Path]*zbstore.Derivation, error) {
+	rewritten := make(map[zbstore.Path]*zbstore.Derivation)
+	for _, drv := range derivations {
+		rewrittenInputs, err := rewriteKeys(drv.InputDerivations, func(k zbstore.Path) (zbstore.Path, error) {
+			return pathForDrvName(maps.Keys(rewritten), string(k))
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%s: input derivations: %v", drv.Name, err)
+		}
+		drv = drv.Clone()
+		drv.InputDerivations = rewrittenInputs
+
+		_, trailer, err := drv.Export(nix.SHA256)
+		if err != nil {
+			return nil, err
+		}
+		drvPath, err := zbstore.FixedCAOutputPath(drv.Dir, drv.Name+zbstore.DerivationExt, trailer.ContentAddress, zbstore.References{
+			Others: trailer.References,
+		})
+		if err != nil {
+			return nil, err
+		}
+		rewritten[drvPath] = drv
+	}
+	return rewritten, nil
+}
+
+// rewriteDesiredOutputsForGraphTest returns a new set of output references
+// based on the keys in outputs and the paths in derivations.
+func rewriteDesiredOutputsForGraphTest(derivations map[zbstore.Path]*zbstore.Derivation, outputs map[string]sets.Set[string]) (sets.Set[zbstore.OutputReference], error) {
+	rewritten := make(sets.Set[zbstore.OutputReference])
+	for drvName, outputNames := range outputs {
+		drvPath, err := pathForDrvName(maps.Keys(derivations), drvName)
+		if err != nil {
+			return nil, fmt.Errorf("desired outputs: %v", err)
+		}
+		for name := range outputNames.All() {
+			rewritten.Add(zbstore.OutputReference{
+				DrvPath:    drvPath,
+				OutputName: name,
+			})
+		}
+	}
+	return rewritten, nil
+}
+
+// pathForDrvName returns the first path that appears in paths
+// that ends with name+[zbstore.DerivationExt]
+// or an error if not found.
+func pathForDrvName(paths iter.Seq[zbstore.Path], name string) (zbstore.Path, error) {
+	for p := range paths {
+		if curr, _ := p.DerivationName(); curr == name {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("no such derivation %s", name)
 }
 
 func rewriteKeys[K1 comparable, K2 comparable, V any, M1 ~map[K1]V](m M1, f func(K1) (K2, error)) (map[K2]V, error) {

--- a/internal/backend/realize.go
+++ b/internal/backend/realize.go
@@ -33,7 +33,6 @@ import (
 	"zb.256lights.llc/pkg/internal/xio"
 	"zb.256lights.llc/pkg/internal/xiter"
 	"zb.256lights.llc/pkg/internal/xmaps"
-	"zb.256lights.llc/pkg/internal/xslices"
 	"zb.256lights.llc/pkg/internal/zbstorerpc"
 	"zb.256lights.llc/pkg/sets"
 	"zb.256lights.llc/pkg/zbstore"
@@ -582,6 +581,7 @@ func (b *builder) obtainBuildRootsForDerivation(ctx context.Context, graph *depe
 	defer b.server.db.Put(conn)
 
 	queue := []zbstore.Path{drvPath}
+	var ignoreStack []zbstore.Path
 	for len(queue) > 0 {
 		curr := queue[0]
 		queue = slices.Delete(queue, 0, 1)
@@ -630,7 +630,8 @@ func (b *builder) obtainBuildRootsForDerivation(ctx context.Context, graph *depe
 		}
 
 	descend:
-		b.ignoreRealizations(graph, roots, curr)
+		ignoreStack = append(ignoreStack, curr)
+		b.ignoreRealizations(graph, roots, &ignoreStack)
 		if len(node.derivation.InputDerivations) == 0 {
 			roots.Add(curr)
 		} else {
@@ -641,12 +642,8 @@ func (b *builder) obtainBuildRootsForDerivation(ctx context.Context, graph *depe
 	return false, nil
 }
 
-func (b *builder) ignoreRealizations(graph *dependencyGraph, roots sets.Set[zbstore.Path], drvPath zbstore.Path) {
-	stack := []zbstore.Path{drvPath}
-	for len(stack) > 0 {
-		curr := xslices.Last(stack)
-		stack = xslices.Pop(stack, 1)
-
+func (b *builder) ignoreRealizations(graph *dependencyGraph, roots sets.Set[zbstore.Path], drvPaths *[]zbstore.Path) {
+	for curr := range graph.transitiveDependents(drvPaths) {
 		h := b.drvHashes[curr]
 		if !h.IsZero() {
 			delete(b.drvHashes, curr)
@@ -659,10 +656,6 @@ func (b *builder) ignoreRealizations(graph *dependencyGraph, roots sets.Set[zbst
 			}
 		}
 		roots.Delete(curr)
-
-		next := graph.nodes[curr].dependents
-		stack = slices.Grow(stack, next.Len())
-		stack = slices.AppendSeq(stack, next.All())
 	}
 }
 


### PR DESCRIPTION
- Add unit tests for `newDependencyOrderIterator`.
- Factor out `*dependencyGraph.transitiveDependents` method, since the same pattern is used in `*builder.ignoreRealizations`.
- Reduce allocations when doing transitive dependents walk by reusing stack between calls.

Fixes #224