### PR TITLE
Add `internal/multierror` package

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"zb.256lights.llc/pkg/bytebuffer"
 	"zb.256lights.llc/pkg/internal/jsonrpc"
+	"zb.256lights.llc/pkg/internal/multierror"
 	"zb.256lights.llc/pkg/internal/xiter"
 	"zb.256lights.llc/pkg/internal/zbstorerpc"
 	"zb.256lights.llc/pkg/sets"
@@ -941,7 +942,7 @@ func (s *Server) copyFromFallback(ctx context.Context, conn *sqlite.Conn, paths 
 		return fmt.Errorf("failed to copy from fallback store: %v", receiveError)
 	}
 
-	var finalError error
+	var ec multierror.Collector
 	for path, eqClassesForPath := range storePathsToDownload {
 		if !pathRecorder.paths.Has(path) {
 			var err error
@@ -950,7 +951,7 @@ func (s *Server) copyFromFallback(ctx context.Context, conn *sqlite.Conn, paths 
 			} else {
 				err = fmt.Errorf("fallback store did not export %s", path)
 			}
-			finalError = errors.Join(finalError, err)
+			ec.Add(err)
 			continue
 		}
 
@@ -969,11 +970,11 @@ func (s *Server) copyFromFallback(ctx context.Context, conn *sqlite.Conn, paths 
 					err = fmt.Errorf("failed to import %s from fallback store", path)
 				}
 			}
-			finalError = errors.Join(finalError, err)
+			ec.Add(err)
 		}
 	}
 
-	return finalError
+	return ec.Error()
 }
 
 func (s *Server) gcLogs(ctx context.Context, window time.Duration) {

--- a/internal/backend/keyring.go
+++ b/internal/backend/keyring.go
@@ -5,9 +5,9 @@ package backend
 
 import (
 	"crypto/ed25519"
-	"errors"
 	"slices"
 
+	"zb.256lights.llc/pkg/internal/multierror"
 	"zb.256lights.llc/pkg/zbstore"
 )
 
@@ -44,14 +44,14 @@ func (k *Keyring) Sign(ref zbstore.RealizationOutputReference, r *zbstore.Realiz
 	}
 
 	result := make([]*zbstore.RealizationSignature, 0, n)
-	var returnedError error
+	var ec multierror.Collector
 	for _, key := range k.Ed25519 {
 		sig, err := zbstore.SignRealizationWithEd25519(ref, r, key)
 		if err != nil {
-			returnedError = errors.Join(returnedError, err)
+			ec.Add(err)
 			continue
 		}
 		result = append(result, sig)
 	}
-	return result, returnedError
+	return result, ec.Error()
 }

--- a/internal/multierror/multierror.go
+++ b/internal/multierror/multierror.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+// Package multierror provides a type for collecting errors.
+package multierror
+
+import (
+	"iter"
+	"slices"
+	"strings"
+)
+
+// A Collector is a list of errors.
+// The zero value is an empty list.
+type Collector struct {
+	errs []error
+}
+
+// Error returns the list of errors as a single [error] value.
+// If the list is empty, then Error returns nil.
+// If the list has a single error, then Error returns it.
+// Otherwise, Error returns an error with an Unwrap() []error method
+// that returns all the errors collected so far.
+func (c *Collector) Error() error {
+	switch {
+	case c == nil || len(c.errs) == 0:
+		return nil
+	case len(c.errs) == 1:
+		return c.errs[0]
+	default:
+		return multiError(c.errs)
+	}
+}
+
+// Add appends an [error] to the list,
+// or does nothing if err is nil.
+// If the error was created by [*Collector.Error],
+// then all the errors are appended to the list.
+func (c *Collector) Add(err error) {
+	if e, ok := err.(multiError); ok {
+		c.errs = append(c.errs, e...)
+	} else if err != nil {
+		c.errs = append(c.errs, err)
+	}
+}
+
+// All returns an iterator over the [error].
+// If the error is nil, then the iterator does not yield anything.
+// If the error was created by [*Collector.Error],
+// then the iterator yields the errors in the order they were added to the [*Collector].
+// Otherwise, the iterator yields the error itself.
+func All(err error) iter.Seq[error] {
+	switch e := err.(type) {
+	case nil:
+		return func(yield func(error) bool) {}
+	case multiError:
+		return slices.Values(e)
+	default:
+		return func(yield func(error) bool) { yield(err) }
+	}
+}
+
+type multiError []error
+
+func (e multiError) Error() string {
+	if len(e) == 1 {
+		return e[0].Error()
+	}
+	sb := new(strings.Builder)
+	sb.WriteString(e[0].Error())
+	for _, err := range e[1:] {
+		sb.WriteByte('\n')
+		sb.WriteString(err.Error())
+	}
+	return sb.String()
+}
+
+func (e multiError) Unwrap() []error {
+	return e
+}

--- a/internal/remotestore/httpstore.go
+++ b/internal/remotestore/httpstore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dsnet/compress/brotli"
 	jsonv2 "github.com/go-json-experiment/json"
 	"zb.256lights.llc/pkg/internal/hal"
+	"zb.256lights.llc/pkg/internal/multierror"
 	"zb.256lights.llc/pkg/internal/useragent"
 	"zb.256lights.llc/pkg/zbstore"
 	"zombiezen.com/go/log"
@@ -90,7 +91,7 @@ func (s *HTTPStore) Object(ctx context.Context, path zbstore.Path) (zbstore.Obje
 		Base:   path.Base(),
 		Digest: path.Digest(),
 	}
-	var allErrors error
+	var ec multierror.Collector
 	for _, link := range infoLinks.Objects {
 		if !link.Templated {
 			return nil, fmt.Errorf("stat %s: link relation %s: not all links are templated", path, narInfoRelation)
@@ -111,14 +112,15 @@ func (s *HTTPStore) Object(ctx context.Context, path zbstore.Path) (zbstore.Obje
 		if statusCode, _ := errorStatusCode(err); statusCode == http.StatusNotFound {
 			log.Debugf(ctx, "NAR info not found: %v", err)
 		} else {
-			allErrors = errors.Join(allErrors, err)
+			ec.Add(err)
 		}
 	}
 
-	if allErrors == nil {
-		allErrors = fmt.Errorf("stat %s: %w", path, zbstore.ErrNotFound)
+	err = ec.Error()
+	if err == nil {
+		err = fmt.Errorf("stat %s: %w", path, zbstore.ErrNotFound)
 	}
-	return nil, allErrors
+	return nil, err
 }
 
 func fetchNARInfo(ctx context.Context, client *http.Client, u *url.URL) (*NARInfo, error) {
@@ -148,12 +150,11 @@ func (s *HTTPStore) FetchRealizations(ctx context.Context, drvHash nix.Hash) (zb
 	if infoLinks.Single {
 		return result, fmt.Errorf("fetch realizations for %v: %v: link relation %s is not an array", drvHash, s.URL.Redacted(), realizationRelation)
 	}
-	var resultError error
+	var ec multierror.Collector
 	for _, link := range infoLinks.Objects {
 		if !link.Templated {
-			err := fmt.Errorf("fetch realizations for %v: %v: link relation %s: not all links are templated",
-				drvHash, s.URL.Redacted(), realizationRelation)
-			resultError = errors.Join(resultError, err)
+			ec.Add(fmt.Errorf("fetch realizations for %v: %v: link relation %s: not all links are templated",
+				drvHash, s.URL.Redacted(), realizationRelation))
 			break
 		}
 	}
@@ -171,21 +172,20 @@ func (s *HTTPStore) FetchRealizations(ctx context.Context, drvHash nix.Hash) (zb
 		}
 		u, err := link.Expand(params)
 		if err != nil {
-			err := fmt.Errorf("fetch realizations for %v: %v: link relation %s: %v",
-				drvHash, s.URL.Redacted(), realizationRelation, err)
-			resultError = errors.Join(resultError, err)
+			ec.Add(fmt.Errorf("fetch realizations for %v: %v: link relation %s: %v",
+				drvHash, s.URL.Redacted(), realizationRelation, err))
 			continue
 		}
 		u = s.URL.ResolveReference(u)
 		if err := s.addRealizations(ctx, &result, u); err != nil {
 			if code, _ := errorStatusCode(err); code != http.StatusNotFound {
-				resultError = errors.Join(resultError, err)
+				ec.Add(err)
 			}
 			continue
 		}
 	}
 
-	return result, resultError
+	return result, ec.Error()
 }
 
 func (s *HTTPStore) addRealizations(ctx context.Context, dst *zbstore.RealizationMap, u *url.URL) error {

--- a/internal/storetest/fakestore.go
+++ b/internal/storetest/fakestore.go
@@ -6,11 +6,11 @@ package storetest
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"sync"
 
+	"zb.256lights.llc/pkg/internal/multierror"
 	"zb.256lights.llc/pkg/sets"
 	"zb.256lights.llc/pkg/zbstore"
 	"zombiezen.com/go/nix"
@@ -68,7 +68,8 @@ func (store *Store) ObjectBatch(ctx context.Context, storePaths sets.Set[zbstore
 func (store *Store) StoreImport(ctx context.Context, r io.Reader) error {
 	recv := &storeReceiver{store: store}
 	err := zbstore.ReceiveExport(recv, r)
-	return errors.Join(recv.error, err)
+	recv.errors.Add(err)
+	return recv.errors.Error()
 }
 
 // FetchRealizations implements [zbstore.RealizationFetcher].
@@ -130,9 +131,9 @@ func (obj *storeObject) Trailer() *zbstore.ExportTrailer {
 }
 
 type storeReceiver struct {
-	store *Store
-	buf   bytes.Buffer
-	error error
+	store  *Store
+	buf    bytes.Buffer
+	errors multierror.Collector
 }
 
 func (s *storeReceiver) Write(p []byte) (n int, err error) {
@@ -145,7 +146,7 @@ func (s *storeReceiver) ReceiveNAR(trailer *zbstore.ExportTrailer) {
 		trailer: *trailer,
 	}
 	if err := zbstore.VerifyObject(context.Background(), obj, nil); err != nil {
-		s.error = errors.Join(s.error, err)
+		s.errors.Add(err)
 		return
 	}
 


### PR DESCRIPTION
Reduces allocations when collecting errors and easier to understand.