### PR TITLE
Validate that a realization's output path has the expected name

### DIFF
--- a/internal/backend/equivalence_class.go
+++ b/internal/backend/equivalence_class.go
@@ -64,6 +64,20 @@ type pathAndEquivalenceClass struct {
 	equivalenceClass equivalenceClass
 }
 
+// derivationPathAndEquivalenceClass holds an [equivalenceClass]
+// and the [zbstore.Path] to a .drv file that matches the realization hash.
+type derivationPathAndEquivalenceClass struct {
+	drvPath          zbstore.Path
+	equivalenceClass equivalenceClass
+}
+
+func (dpe derivationPathAndEquivalenceClass) toOutputReference() zbstore.OutputReference {
+	return zbstore.OutputReference{
+		DrvPath:    dpe.drvPath,
+		OutputName: dpe.equivalenceClass.outputName.Value(),
+	}
+}
+
 // pseudoHashDrv computes a hash of a derivation
 // that can be used for comparing derivations for structural similarity.
 // If hashDrv(drv1) == hashDrv(drv2),

--- a/internal/backend/realization_planner.go
+++ b/internal/backend/realization_planner.go
@@ -96,11 +96,11 @@ func (p *realizationPlanner) commit() {
 //
 // plan may add realizations to p.planned for equivalence classes beyond the given one
 // because selecting a realization may imply selecting realizations from its closure.
-func (p *realizationPlanner) plan(ctx context.Context, conn *sqlite.Conn, eqClass equivalenceClass) {
+func (p *realizationPlanner) plan(ctx context.Context, conn *sqlite.Conn, dpe derivationPathAndEquivalenceClass) {
 	if p.error != nil {
 		return
 	}
-	if _, exists := p.get(eqClass); exists {
+	if _, exists := p.get(dpe.equivalenceClass); exists {
 		return
 	}
 
@@ -111,8 +111,8 @@ func (p *realizationPlanner) plan(ctx context.Context, conn *sqlite.Conn, eqClas
 	}
 	defer rollback()
 
-	log.Debugf(ctx, "Searching for realizations for %v...", eqClass)
-	presentInStore, absentFromStore, err := findPossibleRealizations(ctx, conn, eqClass, p.reusePolicy)
+	log.Debugf(ctx, "Searching for realizations for %v...", dpe.toOutputReference())
+	presentInStore, absentFromStore, err := findPossibleRealizations(ctx, conn, dpe.equivalenceClass, p.reusePolicy)
 	if err != nil {
 		p.error = err
 		return
@@ -120,7 +120,7 @@ func (p *realizationPlanner) plan(ctx context.Context, conn *sqlite.Conn, eqClas
 
 	var r cachedRealization
 	present := false
-	r.path, r.closure, err = p.pick(ctx, conn, eqClass, presentInStore)
+	r.path, r.closure, err = p.pick(ctx, conn, dpe, presentInStore)
 	switch {
 	case err == nil:
 		present = true
@@ -129,9 +129,9 @@ func (p *realizationPlanner) plan(ctx context.Context, conn *sqlite.Conn, eqClas
 			p.error = err
 			return
 		}
-		r.path, r.closure, err = p.pick(ctx, conn, eqClass, absentFromStore)
+		r.path, r.closure, err = p.pick(ctx, conn, dpe, absentFromStore)
 		if errors.Is(err, errMultipleRealizations) {
-			p.error = fmt.Errorf("pick compatible realization for %v: %w", eqClass, errRealizationNotFound)
+			p.error = fmt.Errorf("pick compatible realization for %v: %w", dpe.toOutputReference(), errRealizationNotFound)
 			return
 		}
 		if err != nil {
@@ -144,14 +144,13 @@ func (p *realizationPlanner) plan(ctx context.Context, conn *sqlite.Conn, eqClas
 	}
 
 	// Now that we selected our realization, fill out the closures.
-	log.Debugf(ctx, "Using sole viable candidate %s for %v", r.path, eqClass)
+	log.Debugf(ctx, "Using sole viable candidate %s for %v", r.path, dpe.toOutputReference())
 	for refPath, eqClasses := range r.closure {
 		refPathExists := true
 		if !present {
 			var err error
 			refPathExists, err = objectExists(conn, refPath)
 			if err != nil {
-				p.error = fmt.Errorf("pick compatible realization for %v: %v", eqClass, err)
 				return
 			}
 		}
@@ -176,7 +175,7 @@ func (p *realizationPlanner) plan(ctx context.Context, conn *sqlite.Conn, eqClas
 				return true
 			})
 			if err != nil {
-				p.error = fmt.Errorf("pick compatible realization for %v: %v", eqClass, err)
+				p.error = fmt.Errorf("pick compatible realization for %v: %v", dpe.toOutputReference(), err)
 				return
 			}
 			p.planned[eqClass] = closureRealization
@@ -198,7 +197,7 @@ func (p *realizationPlanner) plan(ctx context.Context, conn *sqlite.Conn, eqClas
 //
 // planSeq may add realizations for equivalence classes beyond the given one
 // because selecting a realization may imply selecting realizations from its closure.
-func (p *realizationPlanner) planSeq(ctx context.Context, conn *sqlite.Conn, eqClasses iter.Seq[equivalenceClass]) {
+func (p *realizationPlanner) planSeq(ctx context.Context, conn *sqlite.Conn, eqClasses iter.Seq[derivationPathAndEquivalenceClass]) {
 	if p.error != nil {
 		return
 	}
@@ -221,22 +220,25 @@ func (p *realizationPlanner) planSeq(ctx context.Context, conn *sqlite.Conn, eqC
 // pick will return an error that unwraps to [errRealizationNotFound]
 // if there is no such realization,
 // or an error that unwraps to [errMultipleRealizations] if there are multiple such realizations.
-func (p *realizationPlanner) pick(ctx context.Context, conn *sqlite.Conn, eqClass equivalenceClass, existing sets.Set[zbstore.Path]) (selectedPath zbstore.Path, closure map[zbstore.Path]sets.Set[equivalenceClass], err error) {
+func (p *realizationPlanner) pick(ctx context.Context, conn *sqlite.Conn, dpe derivationPathAndEquivalenceClass, existing sets.Set[zbstore.Path]) (selectedPath zbstore.Path, closure map[zbstore.Path]sets.Set[equivalenceClass], err error) {
 	rollback, err := readonlySavepoint(conn)
 	if err != nil {
-		return "", nil, fmt.Errorf("pick compatible realization for %v: %v", eqClass, err)
+		return "", nil, fmt.Errorf("pick compatible realization for %v: %v", dpe.toOutputReference(), err)
 	}
 	defer rollback()
 
 	closure = make(map[zbstore.Path]sets.Set[equivalenceClass])
 	remaining := existing.Clone()
 	for outputPath := range existing.All() {
-		log.Debugf(ctx, "Checking whether %s can be used as %v...", outputPath, eqClass)
+		log.Debugf(ctx, "Checking whether %s can be used as %v...", outputPath, dpe.toOutputReference())
 		remaining.Delete(outputPath)
 
+		if !zbstore.IsValidOutputPath(dpe.toOutputReference(), outputPath) {
+			continue
+		}
 		pe := pathAndEquivalenceClass{
 			path:             outputPath,
-			equivalenceClass: eqClass,
+			equivalenceClass: dpe.equivalenceClass,
 		}
 		clear(closure)
 		canUse := true
@@ -247,23 +249,23 @@ func (p *realizationPlanner) pick(ctx context.Context, conn *sqlite.Conn, eqClas
 			} else {
 				r, _ := p.get(ref.equivalenceClass)
 				log.Debugf(ctx, "Cannot use %s as %v: depends on %s (need %s)",
-					outputPath, eqClass, ref.path, r.path)
+					outputPath, dpe.toOutputReference(), ref.path, r.path)
 			}
 			return canUse
 		})
 		if err != nil {
-			return "", nil, fmt.Errorf("pick compatible realization for %v: %v", eqClass, err)
+			return "", nil, fmt.Errorf("pick compatible realization for %v: %v", dpe.toOutputReference(), err)
 		}
 		if canUse {
-			log.Debugf(ctx, "Found %s as a candidate for %v", outputPath, eqClass)
+			log.Debugf(ctx, "Found %s as a candidate for %v", outputPath, dpe.toOutputReference())
 			selectedPath = outputPath
 			break
 		}
 	}
 
 	if selectedPath == "" {
-		log.Debugf(ctx, "No suitable realizations exist for %v", eqClass)
-		return "", nil, fmt.Errorf("pick compatible realization for %v: %w", eqClass, errRealizationNotFound)
+		log.Debugf(ctx, "No suitable realizations exist for %v", dpe.toOutputReference())
+		return "", nil, fmt.Errorf("pick compatible realization for %v: %w", dpe.toOutputReference(), errRealizationNotFound)
 	}
 
 	// In the case where there are multiple valid candidates
@@ -272,7 +274,7 @@ func (p *realizationPlanner) pick(ctx context.Context, conn *sqlite.Conn, eqClas
 	for outputPath := range remaining.All() {
 		pe := pathAndEquivalenceClass{
 			path:             outputPath,
-			equivalenceClass: eqClass,
+			equivalenceClass: dpe.equivalenceClass,
 		}
 		canUse := true
 		err := closurePaths(conn, pe, func(ref pathAndEquivalenceClass) bool {
@@ -280,13 +282,13 @@ func (p *realizationPlanner) pick(ctx context.Context, conn *sqlite.Conn, eqClas
 			return canUse
 		})
 		if err != nil {
-			return "", nil, fmt.Errorf("pick compatible realization for %v: %v", eqClass, err)
+			return "", nil, fmt.Errorf("pick compatible realization for %v: %v", dpe.toOutputReference(), err)
 		}
 		if canUse {
 			// Multiple realizations are compatible.
 			// Return none of them.
-			log.Debugf(ctx, "Both %s and %s are viable candidates for %v. Returning nothing.", outputPath, selectedPath, eqClass)
-			return "", nil, fmt.Errorf("pick compatible realization for %v: %w", eqClass, errMultipleRealizations)
+			log.Debugf(ctx, "Both %s and %s are viable candidates for %v. Returning nothing.", outputPath, selectedPath, dpe.toOutputReference())
+			return "", nil, fmt.Errorf("pick compatible realization for %v: %w", dpe.toOutputReference(), errMultipleRealizations)
 		}
 	}
 

--- a/internal/backend/realize.go
+++ b/internal/backend/realize.go
@@ -311,15 +311,18 @@ func (s *Server) newBuilder(id uuid.UUID, derivations map[zbstore.Path]*zbstore.
 	}
 }
 
-func (b *builder) toEquivalenceClass(ref zbstore.OutputReference) (_ equivalenceClass, ok bool) {
+func (b *builder) toEquivalenceClass(ref zbstore.OutputReference) (_ derivationPathAndEquivalenceClass, ok bool) {
 	if ref.OutputName == "" {
-		return equivalenceClass{}, false
+		return derivationPathAndEquivalenceClass{}, false
 	}
 	h := b.drvHashes[ref.DrvPath]
 	if h.IsZero() {
-		return equivalenceClass{}, false
+		return derivationPathAndEquivalenceClass{}, false
 	}
-	return newEquivalenceClass(h, ref.OutputName), true
+	return derivationPathAndEquivalenceClass{
+		drvPath:          ref.DrvPath,
+		equivalenceClass: newEquivalenceClass(h, ref.OutputName),
+	}, true
 }
 
 // lookup returns the realized path for the given output if the builder realized one.
@@ -328,7 +331,7 @@ func (b *builder) lookup(ref zbstore.OutputReference) (_ zbstore.Path, ok bool) 
 	if !ok {
 		return "", false
 	}
-	r, ok := b.realizations[eqClassRef]
+	r, ok := b.realizations[eqClassRef.equivalenceClass]
 	return r.path, ok
 }
 
@@ -467,13 +470,16 @@ func (b *builder) gatherRealizationsForDerivation(ctx context.Context, curr zbst
 	b.drvHashes[curr] = drvHash
 
 	drvHashKey := makeHashKey(drvHash)
-	wantEqClasses := iter.Seq[equivalenceClass](func(yield func(equivalenceClass) bool) {
+	wantEqClasses := iter.Seq[derivationPathAndEquivalenceClass](func(yield func(derivationPathAndEquivalenceClass) bool) {
 		for outputName := range node.usedOutputs.All() {
-			eqClass := equivalenceClass{
-				drvHashKey: drvHashKey,
-				outputName: outputName,
+			dpe := derivationPathAndEquivalenceClass{
+				drvPath: curr,
+				equivalenceClass: equivalenceClass{
+					drvHashKey: drvHashKey,
+					outputName: outputName,
+				},
 			}
-			if !yield(eqClass) {
+			if !yield(dpe) {
 				return
 			}
 		}
@@ -1037,13 +1043,16 @@ func (b *builder) planRealizationsAndFinalizeBuildResult(ctx context.Context, co
 	defer sqlitex.Save(conn)(&err)
 
 	p := b.newPlanner()
-	p.planSeq(ctx, conn, func(yield func(equivalenceClass) bool) {
+	p.planSeq(ctx, conn, func(yield func(derivationPathAndEquivalenceClass) bool) {
 		for outputName := range state.outputNames.All() {
-			eqClass := equivalenceClass{
-				drvHashKey: state.derivationHashKey,
-				outputName: outputName,
+			dpe := derivationPathAndEquivalenceClass{
+				drvPath: state.drvPath,
+				equivalenceClass: equivalenceClass{
+					drvHashKey: state.derivationHashKey,
+					outputName: outputName,
+				},
 			}
-			if !yield(eqClass) {
+			if !yield(dpe) {
 				return
 			}
 		}
@@ -1167,11 +1176,11 @@ func (b *builder) inputs(conn *sqlite.Conn, drvPath zbstore.Path) (map[zbstore.P
 	}
 	result := make(map[zbstore.Path]sets.Set[equivalenceClass])
 	for input := range drv.InputDerivationOutputs() {
-		eqClass, ok := b.toEquivalenceClass(input)
+		dpe, ok := b.toEquivalenceClass(input)
 		if !ok {
 			return nil, fmt.Errorf("input closure for %s: missing derivation hash for %v", drvPath, input)
 		}
-		out, ok := b.realizations[eqClass]
+		out, ok := b.realizations[dpe.equivalenceClass]
 		if !ok {
 			return nil, fmt.Errorf("input closure for %s: missing realization for %v", drvPath, input)
 		}

--- a/internal/backend/realize_test.go
+++ b/internal/backend/realize_test.go
@@ -1468,6 +1468,116 @@ func TestRealizeSingleDerivationFallback(t *testing.T) {
 	checkSingleFileOutput(t, drvPath, wantOutputPath, []byte(wantOutputContent), got)
 }
 
+func TestRealizeWithImproperlyNamedFallback(t *testing.T) {
+	ctx := testcontext.New(t)
+	dir := backendtest.NewStoreDirectory(t)
+
+	const inputContent = "Hello, World!\n"
+	localExportBuffer := new(bytes.Buffer)
+	exporter := zbstore.NewExportWriter(localExportBuffer)
+	inputFilePath, _, err := storetest.ExportSourceFile(exporter, []byte(inputContent), storetest.SourceExportOptions{
+		Name:      "hello.txt",
+		Directory: dir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drvContent := &zbstore.Derivation{
+		Name:   "hello2.txt",
+		Dir:    dir,
+		System: system.Current().String(),
+		Env: map[string]string{
+			"in":  string(inputFilePath),
+			"out": zbstore.HashPlaceholder(zbstore.DefaultDerivationOutputName),
+		},
+		InputSources: *sets.NewSorted(
+			inputFilePath,
+		),
+		Outputs: map[string]*zbstore.DerivationOutputType{
+			zbstore.DefaultDerivationOutputName: zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+		},
+	}
+	drvContent.Builder, drvContent.Args = catcatBuilder()
+	drvPath, _, err := storetest.ExportDerivation(exporter, drvContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := exporter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	drvHash, err := drvContent.SHA256RealizationHash(func(ref zbstore.OutputReference) (zbstore.Path, bool) {
+		return "", false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fallbackExportBuffer := new(bytes.Buffer)
+	exporter = zbstore.NewExportWriter(fallbackExportBuffer)
+	incorrectOutputPath, _, err := storetest.ExportSourceFile(exporter, []byte("INCORRECT\n"), storetest.SourceExportOptions{
+		Name:      "bork.txt",
+		Directory: dir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := exporter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	fallbackStore := new(storetest.Store)
+	if err := fallbackStore.StoreImport(ctx, fallbackExportBuffer); err != nil {
+		t.Fatal(err)
+	}
+	ref := zbstore.RealizationOutputReference{
+		DerivationHash: drvHash,
+		OutputName:     zbstore.DefaultDerivationOutputName,
+	}
+	fallbackStore.AddRealization(ref, &zbstore.Realization{
+		OutputPath: incorrectOutputPath,
+	})
+
+	_, client, err := backendtest.NewServer(ctx, t, dir, &backendtest.Options{
+		TempDir: t.TempDir(),
+		Options: Options{
+			Fallback: fallbackStore,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	codec, releaseCodec, err := storeCodec(ctx, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = codec.Export(nil, localExportBuffer)
+	releaseCodec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	realizeResponse := new(zbstorerpc.RealizeResponse)
+	err = jsonrpc.Do(ctx, client, zbstorerpc.RealizeMethod, realizeResponse, &zbstorerpc.RealizeRequest{
+		DrvPaths: []zbstore.Path{drvPath},
+		Reuse:    &zbstorerpc.ReusePolicy{All: true},
+	})
+	if err != nil {
+		t.Fatal("RPC error:", err)
+	}
+
+	got, err := backendtest.WaitForSuccessfulBuild(ctx, client, realizeResponse.BuildID)
+	if err != nil {
+		gotLog, _ := backendtest.ReadLog(ctx, client, realizeResponse.BuildID, drvPath)
+		t.Fatalf("build drv: %v\nlog:\n%s", err, gotLog)
+	}
+
+	const wantOutputContent = "Hello, World!\nHello, World!\n"
+	wantOutputPath, err := singleFileOutputPath(dir, drvContent.Name, []byte(wantOutputContent), zbstore.References{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSingleFileOutput(t, drvPath, wantOutputPath, []byte(wantOutputContent), got)
+}
+
 // TestRealizeMultiStepFallback tests a build of drv2 depending on drv1,
 // with a fallback store that has a full realization chain
 // and only includes the output store object for drv2.
@@ -1691,7 +1801,7 @@ func TestRealizeMultiStepFallbackIntermediate(t *testing.T) {
 	exporter = zbstore.NewExportWriter(fallbackExportBuffer)
 	const wantOutputContent1 = inputContent + inputContent
 	wantOutputPath1, _, err := storetest.ExportSourceFile(exporter, []byte(wantOutputContent1), storetest.SourceExportOptions{
-		Name:      drv2Content.Name,
+		Name:      drv1Content.Name,
 		Directory: dir,
 	})
 	if err != nil {

--- a/zbstore/derivation.go
+++ b/zbstore/derivation.go
@@ -333,7 +333,7 @@ func marshalInputDerivations[K ~string](buf []byte, m map[K]*sets.Sorted[string]
 
 // SHA256RealizationHash computes the hash for the given derivation
 // based on the realizations of its input derivations.
-// This hash is intended for use in [newEquivalenceClass].
+// This hash is intended for use in [RealizationOutputReference].
 func (drv *Derivation) SHA256RealizationHash(realization func(ref OutputReference) (Path, bool)) (nix.Hash, error) {
 	if drv.Outputs[DefaultDerivationOutputName].IsFixed() {
 		return hashDrvFixed(drv)
@@ -834,6 +834,18 @@ func (ref *OutputReference) UnmarshalText(text []byte) error {
 	var err error
 	*ref, err = ParseOutputReference(string(text))
 	return err
+}
+
+// IsValidOutputPath reports whether path can be used for the given derivation output.
+func IsValidOutputPath(ref OutputReference, path Path) bool {
+	if path.Dir() != ref.DrvPath.Dir() {
+		return false
+	}
+	suffix, err := ref.Suffix()
+	if err != nil {
+		return false
+	}
+	return path.Name() == suffix
 }
 
 // HashPlaceholder returns the placeholder string used in leiu of a derivation's output path.


### PR DESCRIPTION
Also improves the logging and error messages during realization planning, since I had to plumb through the full derivation path.