### PR TITLE
Return `*resource` from `fetch` instead of just bytes

### DIFF
--- a/internal/remotestore/http.go
+++ b/internal/remotestore/http.go
@@ -17,7 +17,11 @@ import (
 	"zb.256lights.llc/pkg/internal/useragent"
 )
 
-func fetch(ctx context.Context, client *http.Client, u *url.URL, accept string) ([]byte, error) {
+type resource struct {
+	body []byte
+}
+
+func fetch(ctx context.Context, client *http.Client, u *url.URL, accept string) (*resource, error) {
 	req := (&http.Request{
 		Method: http.MethodGet,
 		URL:    u,
@@ -32,38 +36,41 @@ func fetch(ctx context.Context, client *http.Client, u *url.URL, accept string) 
 		return nil, fmt.Errorf("fetch %v: %v", u.Redacted(), err)
 	}
 	defer resp.Body.Close()
+
+	result := &resource{}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch %v: %w", u.Redacted(), &httpError{
+		return result, fmt.Errorf("fetch %v: %w", u.Redacted(), &httpError{
 			statusCode: resp.StatusCode,
 			status:     resp.Status,
 		})
 	}
+
 	const mebibyte = 1 << 20
 	const maxSize = 4 * mebibyte
 	if resp.ContentLength > maxSize {
-		return nil, fmt.Errorf("fetch %v: response too large (%.1f MiB)", u.Redacted(), float64(resp.ContentLength)/mebibyte)
+		return result, fmt.Errorf("fetch %v: response too large (%.1f MiB)", u.Redacted(), float64(resp.ContentLength)/mebibyte)
 	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, maxSize))
+	result.body, err = io.ReadAll(io.LimitReader(resp.Body, maxSize))
 	if err != nil {
-		return nil, fmt.Errorf("fetch %v: %v", u.Redacted(), err)
+		return result, fmt.Errorf("fetch %v: %v", u.Redacted(), err)
 	}
-	if resp.ContentLength == -1 && len(data) == maxSize {
+	if resp.ContentLength == -1 && len(result.body) == maxSize {
 		if n, _ := resp.Body.Read(make([]byte, 1)); n > 0 {
-			return nil, fmt.Errorf("fetch %v: response too large", u.Redacted())
+			return result, fmt.Errorf("fetch %v: response too large", u.Redacted())
 		}
 	}
 	if e := resp.Header.Get("Content-Encoding"); e != "" {
-		dec, err := httpencoding.Decode(bytes.NewReader(data), e)
+		dec, err := httpencoding.Decode(bytes.NewReader(result.body), e)
 		if err != nil {
-			return nil, fmt.Errorf("fetch %v: %v", u.Redacted(), err)
+			return result, fmt.Errorf("fetch %v: %v", u.Redacted(), err)
 		}
 		defer dec.Close()
-		data, err = io.ReadAll(dec)
+		result.body, err = io.ReadAll(dec)
 		if err != nil {
-			return nil, fmt.Errorf("fetch %v: %v", u.Redacted(), err)
+			return result, fmt.Errorf("fetch %v: %v", u.Redacted(), err)
 		}
 	}
-	return data, nil
+	return result, nil
 }
 
 type httpError struct {

--- a/internal/remotestore/httpstore.go
+++ b/internal/remotestore/httpstore.go
@@ -57,12 +57,12 @@ func (s *HTTPStore) discover(ctx context.Context) (*hal.Resource, error) {
 		return nil, fmt.Errorf("get discovery document: url missing")
 	}
 
-	data, err := fetch(ctx, s.client(), s.URL, "application/hal+json,application/json;q=0.9,text/*;q=0.8,*/*;q=0.7")
+	res, err := fetch(ctx, s.client(), s.URL, "application/hal+json,application/json;q=0.9,text/*;q=0.8,*/*;q=0.7")
 	if err != nil {
 		return nil, fmt.Errorf("get discovery document: %v", err)
 	}
 	hr := new(hal.Resource)
-	if err := jsonv2.Unmarshal(data, hr); err != nil {
+	if err := jsonv2.Unmarshal(res.body, hr); err != nil {
 		return nil, fmt.Errorf("get discovery document: %v", err)
 	}
 	return hr, nil
@@ -128,12 +128,12 @@ func (s *HTTPStore) Object(ctx context.Context, path zbstore.Path) (zbstore.Obje
 }
 
 func fetchNARInfo(ctx context.Context, client *http.Client, u *url.URL) (*NARInfo, error) {
-	data, err := fetch(ctx, client, u, "text/x-nix-narinfo,text/*;q=0.9,*/*;q=0.8")
+	res, err := fetch(ctx, client, u, "text/x-nix-narinfo,text/*;q=0.9,*/*;q=0.8")
 	if err != nil {
 		return nil, err
 	}
 	result := new(NARInfo)
-	if err := result.UnmarshalText(data); err != nil {
+	if err := result.UnmarshalText(res.body); err != nil {
 		return nil, fmt.Errorf("fetch %v: %v", u.Redacted(), err)
 	}
 	return result, nil
@@ -200,7 +200,7 @@ func (s *HTTPStore) FetchRealizations(ctx context.Context, drvHash nix.Hash) (zb
 }
 
 func (s *HTTPStore) addRealizations(ctx context.Context, dst *zbstore.RealizationMap, u *url.URL) error {
-	docData, err := fetch(ctx, s.client(), u, "application/json,text/*;q=0.9,*/*;q=0.8")
+	res, err := fetch(ctx, s.client(), u, "application/json,text/*;q=0.9,*/*;q=0.8")
 	if err != nil {
 		if code, _ := errorStatusCode(err); code == http.StatusNotFound || code == http.StatusGone {
 			log.Debugf(ctx, "Fetch realizations for %v: %v", dst.DerivationHash, err)
@@ -210,7 +210,7 @@ func (s *HTTPStore) addRealizations(ctx context.Context, dst *zbstore.Realizatio
 	}
 	doc := new(zbstore.RealizationMap)
 	unmarshalers := jsonv2.UnmarshalFromFunc(zbstore.UnmarshalHashJSONFrom)
-	if err := jsonv2.Unmarshal(docData, doc, jsonv2.WithUnmarshalers(unmarshalers)); err != nil {
+	if err := jsonv2.Unmarshal(res.body, doc, jsonv2.WithUnmarshalers(unmarshalers)); err != nil {
 		return fmt.Errorf("fetch realizations for %v: %v: %v", dst.DerivationHash, u.Redacted(), err)
 	}
 	if err := dst.Merge(*doc); err != nil {


### PR DESCRIPTION
Permits returning response headers that are necessary for conditional PUT requests that update a resource.

Updates #165