### PR TITLE
Use `PRAGMA synchronous=normal` in frontend and backend

### DIFF
--- a/internal/backend/backend_store.go
+++ b/internal/backend/backend_store.go
@@ -1054,6 +1054,9 @@ func prepareConn(conn *sqlite.Conn) error {
 	if err := sqlitex.ExecuteTransient(conn, "PRAGMA journal_mode = wal;", nil); err != nil {
 		return err
 	}
+	if err := sqlitex.ExecuteTransient(conn, "PRAGMA synchronous = normal;", nil); err != nil {
+		return err
+	}
 	if err := sqlitex.ExecuteTransient(conn, "PRAGMA optimize = 0x10002;", nil); err != nil {
 		return err
 	}

--- a/internal/frontend/eval.go
+++ b/internal/frontend/eval.go
@@ -420,6 +420,9 @@ func prepareCache(conn *sqlite.Conn) error {
 	if err := sqlitex.ExecuteTransient(conn, "PRAGMA journal_mode=wal;", nil); err != nil {
 		return fmt.Errorf("enable write-ahead logging: %v", err)
 	}
+	if err := sqlitex.ExecuteTransient(conn, "PRAGMA synchronous=normal;", nil); err != nil {
+		return fmt.Errorf("enable write-ahead logging: %v", err)
+	}
 	if err := sqlitex.ExecuteTransient(conn, "PRAGMA foreign_keys=on;", nil); err != nil {
 		return fmt.Errorf("enable foreign keys: %v", err)
 	}


### PR DESCRIPTION
As per [SQLite docs](https://sqlite.org/pragma.html#pragma_synchronous), "\[t]he `synchronous=NORMAL` setting provides the best balance between performance and safety for most applications running in WAL mode." The frontend uses SQLite as a cache, so stale results in the case of an operating system crash are fine. The backend does not rely on performing syncs for writing store objects, so it is already relying on the operating system to flush.

In micro benchmarks on my desktop, going from `synchronous=FULL` to `synchronous=NORMAL` can speed up transactions by ~100x. This is especially important during realization, which can trigger lots of small transactions quickly.