### PR TITLE
Finish `xhttp.EvaluatePreconditions`

### DIFF
--- a/internal/httpcache/httpcache_test.go
+++ b/internal/httpcache/httpcache_test.go
@@ -596,16 +596,12 @@ func BenchmarkRoundTripper(b *testing.B) {
 		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 		w.Header().Set("ETag", entityTag)
 
-		for _, value := range r.Header.Values("If-None-Match") {
-			for elem := range xhttp.SplitList(value) {
-				if elem == entityTag {
-					w.WriteHeader(http.StatusNotModified)
-					return
-				}
-			}
+		vf := xhttp.ValidatorFields{ETag: entityTag}
+		code := xhttp.EvaluatePreconditions(r.Method, r.Header, vf, true)
+		w.WriteHeader(code)
+		if code == http.StatusOK {
+			io.WriteString(w, content)
 		}
-
-		io.WriteString(w, content)
 	}))
 	b.Cleanup(srv.Close)
 

--- a/internal/xhttp/validators.go
+++ b/internal/xhttp/validators.go
@@ -16,74 +16,103 @@ import (
 //
 // [RFC 9110 Section 8.8]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.8
 type ValidatorFields struct {
-	entityTag    EntityTag
-	lastModified time.Time
+	// ETag is the [entity tag].
+	// It is the empty string if not present.
+	//
+	// [entity tag]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3
+	ETag EntityTag
+	// LastModified is the [Last-Modified field value].
+	// It is the zero time if not present.
+	//
+	// [Last-Modified field value]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.2
+	LastModified time.Time
 }
 
 // ExtractValidatorFields parses the validators from an [http.Header].
 func ExtractValidatorFields(h http.Header) ValidatorFields {
 	var vf ValidatorFields
-	vf.entityTag, _ = EntityTagFromHeader(h)
-	vf.lastModified, _ = dateHeader(h, "Last-Modified")
+	vf.ETag, _ = EntityTagFromHeader(h)
+	vf.LastModified, _ = dateHeader(h, "Last-Modified")
 	return vf
+}
+
+// String formats the fields in a Go-struct-like syntax.
+func (vf ValidatorFields) String() string {
+	sb := new(strings.Builder)
+	sb.WriteString("{")
+	if vf.ETag != "" {
+		sb.WriteString("ETag:")
+		sb.WriteString(string(vf.ETag))
+		if !vf.LastModified.IsZero() {
+			sb.WriteString(" ")
+		}
+	}
+	if !vf.LastModified.IsZero() {
+		sb.WriteString("Last-Modified:")
+		sb.WriteString(vf.LastModified.UTC().Format(http.TimeFormat))
+	}
+	sb.WriteString("}")
+	return sb.String()
 }
 
 // IsZero reports whether vf is the zero value.
 func (vf ValidatorFields) IsZero() bool {
-	return vf.entityTag == "" && vf.lastModified.IsZero()
-}
-
-// ETag returns the [entity tag] from the fields, if present.
-//
-// [entity tag]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3
-func (vf ValidatorFields) ETag() (_ EntityTag, ok bool) {
-	return vf.entityTag, vf.entityTag != ""
-}
-
-// LastModified returns the [Last-Modified field value], if present.
-//
-// [Last-Modified field value]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.2
-func (vf ValidatorFields) LastModified() (_ time.Time, ok bool) {
-	return vf.lastModified, !vf.lastModified.IsZero()
+	return vf.ETag == "" && vf.LastModified.IsZero()
 }
 
 // HasStrong reports whether vf has at least one strong validator.
 func (vf ValidatorFields) HasStrong() bool {
 	// TODO(maybe): RFC 9110 8.8.2.2 states that Last-Modified can be strong
 	// under certain circumstances I don't quite understand.
-	return vf.entityTag.IsStrong()
+	return vf.ETag.IsStrong()
 }
 
 // HasWeak reports whether vf has at least one weak validator.
 func (vf ValidatorFields) HasWeak() bool {
-	return !vf.lastModified.IsZero() || vf.entityTag.IsWeak()
+	return !vf.LastModified.IsZero() || vf.ETag.IsWeak()
 }
 
 // HasAnyStrongFrom reports whether vf contains any of the strong validators in want.
 func (vf ValidatorFields) HasAnyStrongFrom(want ValidatorFields) bool {
-	return vf.entityTag.EqualStrong(want.entityTag)
+	return vf.ETag.EqualStrong(want.ETag)
 }
 
 // HasAnyFrom reports whether vf contains any of the validators in want.
 func (vf ValidatorFields) HasAnyFrom(want ValidatorFields) bool {
-	return vf.entityTag.EqualWeak(want.entityTag) ||
-		!vf.lastModified.IsZero() && !want.lastModified.IsZero()
+	return vf.ETag.EqualWeak(want.ETag) ||
+		!vf.LastModified.IsZero() && !want.LastModified.IsZero()
 }
 
+// EvaluatePreconditions evaluates the preconditions specified in the request header
+// for the request method and the origin server resource's validator fields (if any)
+// and whether the server resource exists.
+// EvaluatePreconditions returns the status code that complies with [RFC 9110 Section 13.2].
+//
+// [RFC 9110 Section 13.2]: https://datatracker.ietf.org/doc/html/rfc9110#section-13.2
 func EvaluatePreconditions(method string, requestHeader http.Header, vf ValidatorFields, exists bool) int {
 	if !exists {
 		vf = ValidatorFields{}
 	}
 
+	if values := requestHeader["If-Match"]; len(values) > 0 {
+		if !evaluateIfMatch(values, vf, exists) {
+			return http.StatusPreconditionFailed
+		}
+	} else if values := requestHeader["If-Unmodified-Since"]; len(values) > 0 {
+		if !evaluateIfUnmodifiedSince(values, vf) {
+			return http.StatusPreconditionFailed
+		}
+	}
+	isGetOrHead := method == "" || method == http.MethodGet || method == http.MethodHead
 	if values := requestHeader["If-None-Match"]; len(values) > 0 {
 		if !evaluateIfNoneMatch(values, vf, exists) {
-			if method == "" || method == http.MethodGet || method == http.MethodHead {
+			if isGetOrHead {
 				return http.StatusNotModified
 			} else {
 				return http.StatusPreconditionFailed
 			}
 		}
-	} else if values := requestHeader["If-Modified-Since"]; len(values) > 0 {
+	} else if values := requestHeader["If-Modified-Since"]; isGetOrHead && len(values) > 0 {
 		if !evaluateIfModifiedSince(values, vf) {
 			return http.StatusNotModified
 		}
@@ -91,19 +120,46 @@ func EvaluatePreconditions(method string, requestHeader http.Header, vf Validato
 
 	// TODO(someday): Range request.
 
-	return http.StatusOK
+	switch {
+	case isGetOrHead && !exists:
+		return http.StatusNotFound
+	case method == http.MethodPut && !exists:
+		return http.StatusCreated
+	default:
+		return http.StatusOK
+	}
+}
+
+func evaluateIfMatch(values []string, vf ValidatorFields, exists bool) bool {
+	if len(values) == 1 && values[0] == "*" {
+		return exists
+	}
+	if len(values) == 0 || len(values) == 1 && strings.Trim(values[0], " \t") == "" {
+		return true
+	}
+	if !vf.ETag.IsValid() || !vf.ETag.IsStrong() {
+		return false
+	}
+	for _, value := range values {
+		for elem := range SplitList(value) {
+			if etag := EntityTag(elem); etag.IsValid() && etag.EqualStrong(vf.ETag) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func evaluateIfNoneMatch(values []string, vf ValidatorFields, exists bool) bool {
 	if len(values) == 1 && values[0] == "*" {
 		return !exists
 	}
-	if vf.entityTag == "" || len(values) == 0 || len(values) == 1 && strings.Trim(values[0], " \t") == "" {
+	if vf.ETag == "" || len(values) == 0 || len(values) == 1 && strings.Trim(values[0], " \t") == "" {
 		return true
 	}
 	for _, value := range values {
 		for elem := range SplitList(value) {
-			if etag := EntityTag(elem); etag.IsValid() && etag.EqualWeak(vf.entityTag) {
+			if etag := EntityTag(elem); etag.IsValid() && etag.EqualWeak(vf.ETag) {
 				return false
 			}
 		}
@@ -112,14 +168,25 @@ func evaluateIfNoneMatch(values []string, vf ValidatorFields, exists bool) bool 
 }
 
 func evaluateIfModifiedSince(values []string, vf ValidatorFields) bool {
-	if len(values) == 0 || vf.lastModified.IsZero() {
+	if len(values) == 0 || vf.LastModified.IsZero() {
 		return true
 	}
 	t, err := http.ParseTime(values[0])
 	if err != nil {
 		return true
 	}
-	return vf.lastModified.After(t)
+	return vf.LastModified.Truncate(time.Second).After(t.Truncate(time.Second))
+}
+
+func evaluateIfUnmodifiedSince(values []string, vf ValidatorFields) bool {
+	if len(values) == 0 || vf.LastModified.IsZero() {
+		return true
+	}
+	t, err := http.ParseTime(values[0])
+	if err != nil {
+		return true
+	}
+	return !vf.LastModified.Truncate(time.Second).After(t.Truncate(time.Second))
 }
 
 // weakEntityTagPrefix is the string that precedes a weak [EntityTag].

--- a/internal/xhttp/validators_test.go
+++ b/internal/xhttp/validators_test.go
@@ -1,0 +1,317 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package xhttp
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestEvaluatePreconditions(t *testing.T) {
+	tests := []struct {
+		name          string
+		method        string
+		requestHeader http.Header
+		vf            ValidatorFields
+		exists        bool
+		want          int
+	}{
+		{
+			name:   "NoRequestHeaders/Get",
+			exists: true,
+			want:   http.StatusOK,
+		},
+		{
+			name:   "NoRequestHeaders/NotFound",
+			exists: false,
+			want:   http.StatusNotFound,
+		},
+		{
+			name:   "NoRequestHeaders/PutOverwrite",
+			method: http.MethodPut,
+			exists: true,
+			want:   http.StatusOK,
+		},
+		{
+			name:   "NoRequestHeaders/PutCreate",
+			method: http.MethodPut,
+			exists: false,
+			want:   http.StatusCreated,
+		},
+		{
+			name:   "IfMatch/Zero",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Match": {`"xyzzy"`},
+			},
+			vf:   ValidatorFields{},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name:   "IfMatch/Matches",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Match": {`"xyzzy"`},
+			},
+			vf: ValidatorFields{
+				ETag: `"xyzzy"`,
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfMatch/MatchMultiple",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Match": {`"abcdef", "xyzzy"`},
+			},
+			vf: ValidatorFields{
+				ETag: `"xyzzy"`,
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfMatch/MatchesPUT",
+			method: http.MethodPut,
+			exists: true,
+			requestHeader: http.Header{
+				"If-Match": {`"xyzzy"`},
+			},
+			vf: ValidatorFields{
+				ETag: `"xyzzy"`,
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfMatch/DoesNotMatch",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Match": {`"bork"`},
+			},
+			vf: ValidatorFields{
+				ETag: `"xyzzy"`,
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name:   "IfMatch/Wildcard",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Match": {`*`},
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfMatch/WildcardNotExist",
+			exists: false,
+			requestHeader: http.Header{
+				"If-Match": {`*`},
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name:   "IfNoneMatch/Zero",
+			exists: true,
+			requestHeader: http.Header{
+				"If-None-Match": {`"xyzzy"`},
+			},
+			vf:   ValidatorFields{},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfNoneMatch/Matches",
+			exists: true,
+			requestHeader: http.Header{
+				"If-None-Match": {`"xyzzy"`},
+			},
+			vf: ValidatorFields{
+				ETag: `"xyzzy"`,
+			},
+			want: http.StatusNotModified,
+		},
+		{
+			name:   "IfNoneMatch/DoesNotMatch",
+			exists: true,
+			requestHeader: http.Header{
+				"If-None-Match": {`"bork"`},
+			},
+			vf: ValidatorFields{
+				ETag: `"xyzzy"`,
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfNoneMatch/MatchesPUT",
+			method: http.MethodPut,
+			exists: true,
+			requestHeader: http.Header{
+				"If-None-Match": {`"xyzzy"`},
+			},
+			vf: ValidatorFields{
+				ETag: `"xyzzy"`,
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name:   "IfNoneMatch/DoesNotMatchPut",
+			method: http.MethodPut,
+			exists: true,
+			requestHeader: http.Header{
+				"If-None-Match": {`"bork"`},
+			},
+			vf: ValidatorFields{
+				ETag: `"xyzzy"`,
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfNoneMatch/WildcardPut",
+			method: http.MethodPut,
+			exists: true,
+			requestHeader: http.Header{
+				"If-None-Match": {`*`},
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name:   "IfNoneMatch/WildcardNotExistPut",
+			method: http.MethodPut,
+			exists: false,
+			requestHeader: http.Header{
+				"If-None-Match": {`*`},
+			},
+			want: http.StatusCreated,
+		},
+		{
+			name:   "IfModifiedSince/Zero",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Modified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf:   ValidatorFields{},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfModifiedSince/Modified",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Modified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.November, 1, 8, 0, 0, 0, time.UTC),
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfModifiedSince/Unmodified",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Modified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.October, 1, 8, 0, 0, 0, time.UTC),
+			},
+			want: http.StatusNotModified,
+		},
+		{
+			name:   "IfModifiedSince/SameSecond",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Modified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.October, 29, 19, 43, 31, int(750*time.Millisecond/time.Nanosecond), time.UTC),
+			},
+			want: http.StatusNotModified,
+		},
+		{
+			name:   "IfModifiedSince/UnmodifiedPut",
+			method: http.MethodPut,
+			exists: true,
+			requestHeader: http.Header{
+				"If-Modified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.October, 1, 8, 0, 0, 0, time.UTC),
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfUnmodifiedSince/Zero",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Unmodified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf:   ValidatorFields{},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfUnmodifiedSince/Modified",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Unmodified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.November, 1, 8, 0, 0, 0, time.UTC),
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name:   "IfUnmodifiedSince/Unmodified",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Unmodified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.October, 1, 8, 0, 0, 0, time.UTC),
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfUnmodifiedSince/SameSecond",
+			exists: true,
+			requestHeader: http.Header{
+				"If-Unmodified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.October, 29, 19, 43, 31, int(750*time.Millisecond/time.Nanosecond), time.UTC),
+			},
+			want: http.StatusOK,
+		},
+		{
+			name:   "IfUnmodifiedSince/ModifiedPut",
+			method: http.MethodPut,
+			exists: true,
+			requestHeader: http.Header{
+				"If-Unmodified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.November, 1, 8, 0, 0, 0, time.UTC),
+			},
+			want: http.StatusPreconditionFailed,
+		},
+		{
+			name:   "IfUnmodifiedSince/UnmodifiedPut",
+			method: http.MethodPut,
+			exists: true,
+			requestHeader: http.Header{
+				"If-Unmodified-Since": {"Sat, 29 Oct 1994 19:43:31 GMT"},
+			},
+			vf: ValidatorFields{
+				LastModified: time.Date(1994, time.October, 1, 8, 0, 0, 0, time.UTC),
+			},
+			want: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := EvaluatePreconditions(test.method, test.requestHeader, test.vf, test.exists)
+			if got != test.want {
+				t.Errorf("EvaluatePreconditions(%s, %v, %v, %t) = %d (%s); want %d (%s)",
+					test.method, test.requestHeader, test.vf, test.exists, got, http.StatusText(got), test.want, http.StatusText(test.want))
+			}
+		})
+	}
+}

--- a/internal/zbstorehttp/http.go
+++ b/internal/zbstorehttp/http.go
@@ -141,13 +141,14 @@ func put(ctx context.Context, client Client, req *putRequest) error {
 	}
 	if req.noReplace {
 		httpRequest.Header.Set("If-None-Match", "*")
-	} else if etag, hasEntityTag := req.precondition.ETag(); hasEntityTag {
-		httpRequest.Header.Set("If-Match", string(etag))
-	} else if lastModified, ok := req.precondition.LastModified(); ok {
+	} else if req.precondition.ETag != "" {
+		httpRequest.Header.Set("If-Match", string(req.precondition.ETag))
+	} else if !req.precondition.LastModified.IsZero() {
 		// As per https://datatracker.ietf.org/doc/html/rfc9110#section-13.1.4,
 		// "[a] recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field [...]".
 		// Thus, we avoid sending the header field if we already have an entity tag.
-		httpRequest.Header.Set("If-Unmodified-Since", lastModified.UTC().Format(http.TimeFormat))
+		v := req.precondition.LastModified.UTC().Format(http.TimeFormat)
+		httpRequest.Header.Set("If-Unmodified-Since", v)
 	}
 	if req.cacheControl != "" {
 		httpRequest.Header.Set("Cache-Control", req.cacheControl)


### PR DESCRIPTION
- Change `xhttp.ValidatorFields` accessor methods to exported fields.
- Add unit tests for `xhttp.EvalutatePreconditions`.
- Use `xhttp.EvalutatePreconditions` in `internal/httpcache` benchmarks.

Updates #258