### PR TITLE
Ignore empty elements in `xhttp.SplitList`

### DIFF
--- a/internal/xhttp/xhttp.go
+++ b/internal/xhttp/xhttp.go
@@ -38,20 +38,27 @@ func IsFinalStatusCode(code int) bool {
 	return 200 <= code && code < 600
 }
 
+// whitespace is the set of whitespace characters
+// as defined in [RFC 9110 Section 5.6.3].
+//
+// [RFC 9110 Section 5.6.3]: https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.3
+const whitespace = " \t"
+
 // SplitList splits an HTTP header [list value],
 // handling [quoted strings].
 //
-// [list value]: https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1
-// [quoted strings]: https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4
+// [list value]: https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.1
+// [quoted strings]: https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.4
 func SplitList(value string) iter.Seq[string] {
-	const ows = " \t"
 	return func(yield func(string) bool) {
 		i := 0
 		for j := 0; j < len(value); j++ {
 			switch value[j] {
 			case ',':
-				if !yield(strings.Trim(value[i:j], ows)) {
-					return
+				if elem := strings.Trim(value[i:j], whitespace); elem != "" {
+					if !yield(elem) {
+						return
+					}
 				}
 				i = j + 1
 			case '"':
@@ -65,7 +72,9 @@ func SplitList(value string) iter.Seq[string] {
 				}
 			}
 		}
-		yield(strings.Trim(value[i:], ows))
+		if elem := strings.Trim(value[i:], whitespace); elem != "" {
+			yield(elem)
+		}
 	}
 }
 

--- a/internal/xhttp/xhttp_test.go
+++ b/internal/xhttp/xhttp_test.go
@@ -4,9 +4,38 @@
 package xhttp
 
 import (
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
+
+func TestSplitList(t *testing.T) {
+	tests := []struct {
+		value string
+		want  []string
+	}{
+		{"", nil},
+		{",", nil},
+		{",   ,", nil},
+		{"foo,bar", []string{"foo", "bar"}},
+		{"foo, bar", []string{"foo", "bar"}},
+		{"foo ,bar,", []string{"foo", "bar"}},
+		{"  foo \t , bar \t ", []string{"foo", "bar"}},
+		{"foo , ,bar,charlie", []string{"foo", "bar", "charlie"}},
+		{`no-cache="X-Foo,\"X-Bar",max-age=5`, []string{`no-cache="X-Foo,\"X-Bar"`, "max-age=5"}},
+		{`no-cache="\`, []string{`no-cache="\`}},
+	}
+
+	for _, test := range tests {
+		got := slices.Collect(SplitList(test.value))
+		if diff := cmp.Diff(test.want, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("SplitList(%q) (-want +got):\n%s", test.value, diff)
+		}
+	}
+}
 
 func TestIsTokenChar(t *testing.T) {
 	sb := new(strings.Builder)


### PR DESCRIPTION
Part of the [list recipient requirements][RFC 9110 Section 5.6.1.2].

[RFC 9110 Section 5.6.1.2]: https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.1.2

<!-- jj-domino -->
<!-- Do not remove this comment! Everything in this section will be rewritten by jj-domino. -->

## Related Pull Requests

This pull request is part of a stack managed by [jj-domino](https://github.com/zombiezen/jj-domino):

 1. *→ this pull request ←*
 2. #271
