### PR TITLE
Remove `xslices.Filter` function

### DIFF
--- a/internal/backend/graph.go
+++ b/internal/backend/graph.go
@@ -251,7 +251,9 @@ func newDependencyOrderIterator(g *dependencyGraph, roots iter.Seq[zbstore.Path]
 			}
 		}
 	}
-	rootList = xslices.Filter(rootList, rootSet.Has)
+	rootList = slices.DeleteFunc(rootList, func(p zbstore.Path) bool {
+		return !rootSet.Has(p)
+	})
 
 	return &dependencyOrderIterator{
 		graph:    g,

--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"zb.256lights.llc/pkg/internal/xhttp"
-	"zb.256lights.llc/pkg/internal/xslices"
 	"zb.256lights.llc/pkg/internal/xtime"
 	"zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitefile"
@@ -299,7 +298,9 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			Request: req,
 		}, nil
 	}
-	responses = xslices.Filter(responses, (*storedResponse).responseReceived)
+	responses = slices.DeleteFunc(responses, func(resp *storedResponse) bool {
+		return !resp.responseReceived()
+	})
 
 	startedAt := time.Now()
 	ch := make(chan allocateResourceResult)

--- a/internal/lua/functions.go
+++ b/internal/lua/functions.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 
 	"zb.256lights.llc/pkg/internal/luacode"
-	"zb.256lights.llc/pkg/internal/xslices"
 )
 
 // A Function is a callback for a Lua function implemented in Go.
@@ -201,13 +200,13 @@ func (l *State) checkUpvalues(top int, upvalues []*upvalue) error {
 // This is distinct from calling the “__close” metamethods,
 // but often happens at the same time.
 func (l *State) closeUpvalues(bottom int) {
-	l.pendingVariables = xslices.Filter(l.pendingVariables, func(uv *upvalue) bool {
+	l.pendingVariables = slices.DeleteFunc(l.pendingVariables, func(uv *upvalue) bool {
 		if uv.isOpen() && uv.stackIndex >= bottom {
 			// Close the upvalue.
 			uv.storage = l.stack[uv.stackIndex]
 			uv.stackIndex = -1
-			return false
+			return true
 		}
-		return true
+		return false
 	})
 }

--- a/internal/xslices/xslices.go
+++ b/internal/xslices/xslices.go
@@ -20,20 +20,6 @@ func Pop[S ~[]E, E any](s S, n int) S {
 	return s[:end]
 }
 
-// Filter removes any element x from s for which f(x) reports false,
-// returning the modified slice.
-func Filter[S ~[]E, E any](s S, f func(E) bool) S {
-	n := 0
-	for _, x := range s {
-		if f(x) {
-			s[n] = x
-			n++
-		}
-	}
-	clear(s[n:])
-	return s[:n]
-}
-
 // ClonePointers returns a copy of the slice.
 // The referenced values are copied using assignment,
 // so this is a clone with depth of 1.


### PR DESCRIPTION
Redundant with `slices.DeleteFunc`. I somehow overlooked `slices.DeleteFunc` when I wrote `xslices.Filter`.