### PR TITLE
Prune gRPC dependencies from release builds

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -109,7 +109,9 @@ function module.new(args)
     busybox = busybox;
 
     preBuild = [[export GOCACHE="$ZB_BUILD_TOP/cache"]];
-    buildPhase = [[go build -trimpath -ldflags="-s -w -X main.zbVersion=$version" zb.256lights.llc/pkg/cmd/zb]];
+    -- See https://pkg.go.dev/cloud.google.com/go/storage#hdr-gRPC_API
+    -- for info about -tags=disable_grpc_modules.
+    buildPhase = [[go build -trimpath -ldflags="-s -w -X main.zbVersion=$version" -tags=disable_grpc_modules zb.256lights.llc/pkg/cmd/zb]];
     installPhase = [=[
 mkdir -p "$out/bin"
 name="zb$(go env GOEXE)"

--- a/package.nix
+++ b/package.nix
@@ -14,6 +14,9 @@ buildGoModule {
   ldflags = [
     "-s -w -X main.zbVersion=${version}"
   ];
+  tags = [
+    "disable_grpc_modules"
+  ];
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
We are only using the JSON API, not the gRPC API, for Google Cloud Storage. This change shaves ~10MiB off the release binary!