### PR TITLE
Inform backend to copy objects named in `storePath` function from fallback

### DIFF
--- a/cmd/zb/main.go
+++ b/cmd/zb/main.go
@@ -391,6 +391,17 @@ type rpcStore struct {
 	reuse      *zbstorerpc.ReusePolicy
 }
 
+func (store *rpcStore) FetchObjects(ctx context.Context, paths []zbstore.Path) (map[zbstore.Path]*zbstorerpc.ObjectInfo, error) {
+	var resp zbstorerpc.FetchResponse
+	err := jsonrpc.Do(ctx, store.Handler, zbstorerpc.FetchMethod, &resp, &zbstorerpc.FetchRequest{
+		Paths: paths,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Found, nil
+}
+
 func (store *rpcStore) Realize(ctx context.Context, want sets.Set[zbstore.OutputReference]) ([]*zbstorerpc.BuildResult, error) {
 	var realizeResponse zbstorerpc.RealizeResponse
 	err := jsonrpc.Do(ctx, store.Handler, zbstorerpc.RealizeMethod, &realizeResponse, &zbstorerpc.RealizeRequest{

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -276,13 +276,46 @@ func NewServer(dir zbstore.Directory, dbPath string, opts *Options) *Server {
 	return srv
 }
 
-// detach calls f in its own goroutine
+// detachFromRPC calls f in its own goroutine
+// with a [context.Context] whose values are taken from parent
+// and its cancellation from s.backgroundContext.
+// detachFromRPC returns an error if it did not start a goroutine
+// because the server is currently draining.
+func (s *Server) detachFromRPC(parent context.Context, f func(context.Context)) error {
+	s.activeBuildsMu.Lock()
+	draining := s.drained != nil
+	if !draining {
+		s.activeWork++
+	}
+	s.activeBuildsMu.Unlock()
+
+	if draining {
+		return errors.New("server shutting down; not starting new work")
+	}
+
+	s.background.Go(func() {
+		defer func() {
+			s.activeBuildsMu.Lock()
+			s.activeWork--
+			s.lockedUpdateDrained()
+			s.activeBuildsMu.Unlock()
+		}()
+
+		f(splitContext{
+			cancel: s.backgroundContext,
+			values: parent,
+		})
+	})
+	return nil
+}
+
+// detachFromBuild calls f in its own goroutine
 // with a [context.Context] whose values are taken from parent
 // and its cancellation from s.backgroundContext.
 //
-// detach does not check for draining,
-// since it is assumed that detach will only be called during a build.
-func (s *Server) detach(parent context.Context, f func(context.Context)) {
+// detachFromBuild does not check for draining,
+// since detachFromBuild will only be called during a build.
+func (s *Server) detachFromBuild(parent context.Context, f func(context.Context)) {
 	s.activeBuildsMu.Lock()
 	s.activeWork++
 	s.activeBuildsMu.Unlock()
@@ -366,6 +399,7 @@ func (s *Server) JSONRPC(ctx context.Context, req *jsonrpc.Request) (*jsonrpc.Re
 		zbstorerpc.GetBuildResultMethod: jsonrpc.HandlerFunc(s.getBuildResult),
 		zbstorerpc.CancelBuildMethod:    jsonrpc.HandlerFunc(s.cancelBuild),
 		zbstorerpc.ReadLogMethod:        jsonrpc.HandlerFunc(s.readLog),
+		zbstorerpc.FetchMethod:          jsonrpc.HandlerFunc(s.fetch),
 
 		zbstorerpc.NopMethod: jsonrpc.HandlerFunc(func(ctx context.Context, req *jsonrpc.Request) (*jsonrpc.Response, error) {
 			return &jsonrpc.Response{
@@ -938,6 +972,73 @@ func (s *Server) delete(ctx context.Context, paths sets.Set[zbstore.Path], recur
 		return fmt.Errorf("one or more store paths could not be deleted")
 	}
 	return nil
+}
+
+func (s *Server) fetch(ctx context.Context, req *jsonrpc.Request) (*jsonrpc.Response, error) {
+	var args zbstorerpc.FetchRequest
+	if err := jsonv2.Unmarshal(req.Params, &args); err != nil {
+		return nil, jsonrpc.Error(jsonrpc.InvalidParams, err)
+	}
+	if len(args.Paths) == 0 {
+		return marshalResponse(&zbstorerpc.FetchResponse{})
+	}
+
+	// Since the copy can take a while, detach the copy operation from this RPC.
+	// We'll block on it for as long as we can,
+	// and the caller can retry the RPC and it will eventually not block.
+	copyDone := make(chan struct{})
+	err := s.detachFromRPC(ctx, func(ctx context.Context) {
+		defer close(copyDone)
+		conn, err := s.db.Get(ctx)
+		if err != nil {
+			return
+		}
+		defer s.db.Put(conn)
+		err = s.copyFromFallback(ctx, conn, func(yield func(pathAndEquivalenceClass) bool) {
+			for _, path := range args.Paths {
+				pe := pathAndEquivalenceClass{path: path}
+				if !yield(pe) {
+					return
+				}
+			}
+		})
+		if err != nil {
+			log.Infof(ctx, "After fetch: %v", err)
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	select {
+	case <-copyDone:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	conn, err := s.db.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.db.Put(conn)
+	rollback, err := readonlySavepoint(conn)
+	if err != nil {
+		return nil, err
+	}
+	defer rollback()
+
+	resp := &zbstorerpc.FetchResponse{
+		Found: make(map[zbstore.Path]*zbstorerpc.ObjectInfo, len(args.Paths)),
+	}
+	for _, path := range args.Paths {
+		info, err := pathInfo(conn, path)
+		if err == nil {
+			resp.Found[path] = info.ToRPC()
+		} else if !errors.Is(err, zbstore.ErrNotFound) {
+			return nil, err
+		}
+	}
+	return marshalResponse(resp)
 }
 
 // copyFromFallback imports any store objects identified by paths

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -6,6 +6,7 @@ package backend_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "zb.256lights.llc/pkg/internal/backend"
 	"zb.256lights.llc/pkg/internal/backendtest"
 	"zb.256lights.llc/pkg/internal/jsonrpc"
@@ -163,6 +165,140 @@ func TestImport(t *testing.T) {
 
 	t.Run("MappedDir", func(t *testing.T) {
 		runTest(t, zbstore.DefaultDirectory(), t.TempDir())
+	})
+}
+
+func TestFetch(t *testing.T) {
+	dir := zbstore.DefaultDirectory()
+	exportBuffer := new(bytes.Buffer)
+	exporter := zbstore.NewExportWriter(exportBuffer)
+	narBuffer := new(bytes.Buffer)
+	if err := storetest.SingleFileNAR(narBuffer, []byte("Hello, World!\n")); err != nil {
+		t.Fatal(err)
+	}
+	narHash := nix.NewHash(nix.SHA256, new(sha256.Sum256(narBuffer.Bytes()))[:])
+	path, ca, err := storetest.ExportSourceNAR(exporter, narBuffer.Bytes(), storetest.SourceExportOptions{
+		Name:      "hello.txt",
+		Directory: dir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := exporter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("NotFound", func(t *testing.T) {
+		ctx := testcontext.New(t)
+		realStoreDir := t.TempDir()
+		_, client, err := backendtest.NewServer(ctx, t, dir, &backendtest.Options{
+			TempDir: t.TempDir(),
+			Options: Options{
+				RealStoreDirectory: realStoreDir,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := new(zbstorerpc.FetchResponse)
+		err = jsonrpc.Do(ctx, client, zbstorerpc.FetchMethod, got, &zbstorerpc.FetchRequest{
+			Paths: []zbstore.Path{path},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := &zbstorerpc.FetchResponse{
+			Found: map[zbstore.Path]*zbstorerpc.ObjectInfo{},
+		}
+		if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("response (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("ExistsLocally", func(t *testing.T) {
+		ctx := testcontext.New(t)
+		realStoreDir := t.TempDir()
+		_, client, err := backendtest.NewServer(ctx, t, dir, &backendtest.Options{
+			TempDir: t.TempDir(),
+			Options: Options{
+				RealStoreDirectory: realStoreDir,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		codec, releaseCodec, err := storeCodec(ctx, client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = codec.Export(nil, bytes.NewReader(exportBuffer.Bytes()))
+		releaseCodec()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := new(zbstorerpc.FetchResponse)
+		err = jsonrpc.Do(ctx, client, zbstorerpc.FetchMethod, got, &zbstorerpc.FetchRequest{
+			Paths: []zbstore.Path{path},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := &zbstorerpc.FetchResponse{
+			Found: map[zbstore.Path]*zbstorerpc.ObjectInfo{
+				path: {
+					CA:      ca,
+					NARSize: int64(narBuffer.Len()),
+					NARHash: narHash,
+				},
+			},
+		}
+		if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("response (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("FromFallback", func(t *testing.T) {
+		ctx := testcontext.New(t)
+
+		fallback := new(storetest.Store)
+		if err := fallback.StoreImport(ctx, bytes.NewReader(exportBuffer.Bytes())); err != nil {
+			t.Fatal(err)
+		}
+
+		realStoreDir := t.TempDir()
+		_, client, err := backendtest.NewServer(ctx, t, dir, &backendtest.Options{
+			TempDir: t.TempDir(),
+			Options: Options{
+				RealStoreDirectory: realStoreDir,
+				Fallback:           fallback,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := new(zbstorerpc.FetchResponse)
+		err = jsonrpc.Do(ctx, client, zbstorerpc.FetchMethod, got, &zbstorerpc.FetchRequest{
+			Paths: []zbstore.Path{path},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := &zbstorerpc.FetchResponse{
+			Found: map[zbstore.Path]*zbstorerpc.ObjectInfo{
+				path: {
+					CA:      ca,
+					NARSize: int64(narBuffer.Len()),
+					NARHash: narHash,
+				},
+			},
+		}
+		if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("response (-want +got):\n%s", diff)
+		}
 	})
 }
 

--- a/internal/backend/realize.go
+++ b/internal/backend/realize.go
@@ -914,7 +914,7 @@ func (b *builder) do(ctx context.Context, drvPath zbstore.Path, outputNames sets
 
 	if b.server.upload != nil {
 		srv := b.server
-		srv.detach(ctx, func(ctx context.Context) {
+		srv.detachFromBuild(ctx, func(ctx context.Context) {
 			srv.uploadClosure(ctx, slices.Values(objectsToUpload))
 		})
 	}
@@ -1868,7 +1868,7 @@ func (b *builder) recordRealizations(ctx context.Context, conn *sqlite.Conn, bui
 
 	if b.server.upload != nil {
 		srv := b.server
-		srv.detach(ctx, func(ctx context.Context) {
+		srv.detachFromBuild(ctx, func(ctx context.Context) {
 			srv.uploadRealizations(ctx, outputs)
 		})
 	}

--- a/internal/frontend/eval.go
+++ b/internal/frontend/eval.go
@@ -84,6 +84,10 @@ type Store interface {
 	zbstore.Store
 	zbstore.Importer
 
+	// FetchObjects gets information about existing objects
+	// and/or attempts to download objects from another source.
+	FetchObjects(ctx context.Context, paths []zbstore.Path) (map[zbstore.Path]*zbstorerpc.ObjectInfo, error)
+
 	// Realize starts a build for the given derivation paths,
 	// waits for the build to finish,
 	// then returns the results of the build.
@@ -333,10 +337,12 @@ func (eval *Eval) storePathFunction(ctx context.Context, l *lua.State) (int, err
 		return 0, fmt.Errorf("%sstorePath: path %s is not under %s",
 			lua.Where(l, 1), lualex.Quote(rawPath), lualex.Quote(string(eval.storeDir)))
 	}
-	if _, err := eval.store.Object(ctx, path); errors.Is(err, zbstore.ErrNotFound) {
-		return 0, fmt.Errorf("%sstorePath: %s does not exist", lua.Where(l, 1), path)
-	} else if err != nil {
+	objects, err := eval.store.FetchObjects(ctx, []zbstore.Path{path})
+	if err != nil {
 		return 0, fmt.Errorf("%sstorePath: %v", lua.Where(l, 1), err)
+	}
+	if objects[path] == nil {
+		return 0, fmt.Errorf("%sstorePath: %s does not exist", lua.Where(l, 1), path)
 	}
 	l.PushStringContext(rawPath, sets.New(contextValue{path: path}.String()))
 	return 1, nil

--- a/internal/frontend/eval_test.go
+++ b/internal/frontend/eval_test.go
@@ -4,7 +4,9 @@
 package frontend
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -15,10 +17,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"zb.256lights.llc/pkg/internal/backend"
 	"zb.256lights.llc/pkg/internal/backendtest"
 	"zb.256lights.llc/pkg/internal/jsonrpc"
 	"zb.256lights.llc/pkg/internal/lua"
 	"zb.256lights.llc/pkg/internal/lualex"
+	"zb.256lights.llc/pkg/internal/storetest"
 	"zb.256lights.llc/pkg/internal/system"
 	"zb.256lights.llc/pkg/internal/testcontext"
 	"zb.256lights.llc/pkg/internal/zbstorerpc"
@@ -390,6 +394,121 @@ func TestImportCycle(t *testing.T) {
 	})
 }
 
+func TestStorePath(t *testing.T) {
+	t.Run("ExistsLocally", func(t *testing.T) {
+		ctx := testcontext.New(t)
+
+		storeDir := backendtest.NewStoreDirectory(t)
+		exportBuffer := new(bytes.Buffer)
+		exporter := zbstore.NewExportWriter(exportBuffer)
+		wantPath, _, err := storetest.ExportSourceFile(exporter, []byte("Hello, World!\n"), storetest.SourceExportOptions{
+			Name:      "hello.txt",
+			Directory: storeDir,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := exporter.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		di := new(zbstorerpc.DeferredImporter)
+		_, store, err := backendtest.NewServer(ctx, t, storeDir, &backendtest.Options{
+			TempDir: t.TempDir(),
+			ClientOptions: zbstorerpc.CodecOptions{
+				Importer: di,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rpcStore := newTestRPCStore(store, di)
+		if err := rpcStore.StoreImport(ctx, exportBuffer); err != nil {
+			t.Fatal(err)
+		}
+
+		eval, err := NewEval(&Options{
+			Store:          rpcStore,
+			StoreDirectory: storeDir,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := eval.Close(); err != nil {
+				t.Error("eval.Close:", err)
+			}
+		}()
+
+		got, err := eval.Expression(ctx, "storePath("+lualex.Quote(string(wantPath))+")")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := string(wantPath)
+		if !cmp.Equal(want, got) {
+			t.Errorf("storePath(%q) = %#v; want %#v", wantPath, got, want)
+		}
+	})
+
+	t.Run("FromFallback", func(t *testing.T) {
+		ctx := testcontext.New(t)
+
+		storeDir := backendtest.NewStoreDirectory(t)
+		exportBuffer := new(bytes.Buffer)
+		exporter := zbstore.NewExportWriter(exportBuffer)
+		wantPath, _, err := storetest.ExportSourceFile(exporter, []byte("Hello, World!\n"), storetest.SourceExportOptions{
+			Name:      "hello.txt",
+			Directory: storeDir,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := exporter.Close(); err != nil {
+			t.Fatal(err)
+		}
+		fallback := new(storetest.Store)
+		if err := fallback.StoreImport(ctx, bytes.NewReader(exportBuffer.Bytes())); err != nil {
+			t.Fatal(err)
+		}
+
+		di := new(zbstorerpc.DeferredImporter)
+		_, store, err := backendtest.NewServer(ctx, t, storeDir, &backendtest.Options{
+			TempDir: t.TempDir(),
+			Options: backend.Options{
+				Fallback: fallback,
+			},
+			ClientOptions: zbstorerpc.CodecOptions{
+				Importer: di,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		eval, err := NewEval(&Options{
+			Store:          newTestRPCStore(store, di),
+			StoreDirectory: storeDir,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := eval.Close(); err != nil {
+				t.Error("eval.Close:", err)
+			}
+		}()
+
+		got, err := eval.Expression(ctx, "storePath("+lualex.Quote(string(wantPath))+")")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := string(wantPath)
+		if !cmp.Equal(want, got) {
+			t.Errorf("storePath(%q) = %#v; want %#v", wantPath, got, want)
+		}
+	})
+}
+
 func TestExtract(t *testing.T) {
 	ctx := testcontext.New(t)
 	storeDir := backendtest.NewStoreDirectory(t)
@@ -626,6 +745,17 @@ func (store *testRPCStore) StoreImport(ctx context.Context, r io.Reader) error {
 	return err
 }
 
+func (store *testRPCStore) FetchObjects(ctx context.Context, paths []zbstore.Path) (map[zbstore.Path]*zbstorerpc.ObjectInfo, error) {
+	var resp zbstorerpc.FetchResponse
+	err := jsonrpc.Do(ctx, store.Handler, zbstorerpc.FetchMethod, &resp, &zbstorerpc.FetchRequest{
+		Paths: paths,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Found, nil
+}
+
 func (store *testRPCStore) Realize(ctx context.Context, want sets.Set[zbstore.OutputReference]) ([]*zbstorerpc.BuildResult, error) {
 	var realizeResponse zbstorerpc.RealizeResponse
 	err := jsonrpc.Do(ctx, store.Handler, zbstorerpc.RealizeMethod, &realizeResponse, &zbstorerpc.RealizeRequest{
@@ -660,6 +790,19 @@ func (e exportSpy) ReceiveNAR(trailer *zbstore.ExportTrailer) {
 	e.store.mu.Lock()
 	defer e.store.mu.Unlock()
 	e.store.imports = append(e.store.imports, trailer.StorePath)
+}
+
+func storeCodec(ctx context.Context, client *jsonrpc.Client) (codec *zbstorerpc.Codec, release func(), err error) {
+	generic, release, err := client.Codec(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	codec, ok := generic.(*zbstorerpc.Codec)
+	if !ok {
+		release()
+		return nil, nil, fmt.Errorf("store connection is %T (want %T)", generic, (*zbstorerpc.Codec)(nil))
+	}
+	return codec, release, nil
 }
 
 func TestMain(m *testing.M) {

--- a/internal/zbstorerpc/zbstorerpc.go
+++ b/internal/zbstorerpc/zbstorerpc.go
@@ -371,6 +371,23 @@ func (resp *ReadLogResponse) SetPayload(src []byte) {
 	}
 }
 
+// FetchMethod is the name of the method that either gets information about existing objects
+// and/or attempts to download objects from another source.
+// [FetchRequest] is used for the request
+// and [FetchResponse] is used for the response.
+const FetchMethod = "zb.fetch"
+
+// FetchRequest is the set of parameters for [FetchMethod].
+type FetchRequest struct {
+	Paths []zbstore.Path `json:"paths"`
+}
+
+// FetchResponse is the result for [FetchMethod].
+type FetchResponse struct {
+	// Found is the information for the objects that exist in the store.
+	Found map[zbstore.Path]*ObjectInfo `json:"found"`
+}
+
 // ExportMethod is the name of the method that triggers an export of store objects.
 // [ExportRequest] is used for the request and the response is null.
 const ExportMethod = "zb.export"


### PR DESCRIPTION
Added a "fetch" RPC to the backend that acts like the "info" RPC, but acts on a batch and will get-or-create. Canceling the RPC doesn't cancel the copy operation so that the store has more objects.

Fixes #221