### PR TITLE
Add GraphViz output for derivation graphs

### DIFF
--- a/cmd/zb/derivation.go
+++ b/cmd/zb/derivation.go
@@ -35,7 +35,8 @@ func (c *derivationCommand) Signature() string {
 
 type derivationShowCommand struct {
 	evalOptions `kong:"embed"`
-	JSONFormat  bool `kong:"name=json,help=Print derivation as JSON."`
+	JSONFormat  bool `kong:"name=json,xor=derivation_show_format,help=Print derivation as JSON."`
+	DOTFormat   bool `kong:"name=dot,xor=derivation_show_format,help=Print the recursive derivation dependency graph as GraphViz DOT."`
 }
 
 func (c *derivationShowCommand) Signature() string {
@@ -65,6 +66,24 @@ func (c *derivationShowCommand) Run(ctx context.Context, g *globalConfig) error 
 		}
 		if !slices.Contains(drvPaths, "") {
 			// Fast path: don't connect to the store. All arguments are local paths to .drv files.
+			if c.DOTFormat {
+				roots := make(map[string]*zbstore.Derivation, len(drvPaths))
+				for _, drvPath := range drvPaths {
+					absolutePath, drv, err := parseDerivationFile(drvPath)
+					if err != nil {
+						return err
+					}
+					roots[absolutePath] = drv
+				}
+				closure, err := collectDerivationClosure(ctx, roots, loadLocalDerivations)
+				if err != nil {
+					return err
+				}
+				if _, err := os.Stdout.Write(marshalDerivationDOT(closure)); err != nil {
+					return err
+				}
+				return nil
+			}
 			for _, drvPath := range drvPaths {
 				drvBytes, err := showDerivationFile(drvPath, c.JSONFormat)
 				if err != nil {
@@ -100,9 +119,12 @@ func (c *derivationShowCommand) Run(ctx context.Context, g *globalConfig) error 
 	if err != nil {
 		return err
 	}
+	evalClosed := false
 	defer func() {
-		if err := eval.Close(); err != nil {
-			log.Errorf(ctx, "%v", err)
+		if !evalClosed {
+			if err := eval.Close(); err != nil {
+				log.Errorf(ctx, "%v", err)
+			}
 		}
 	}()
 
@@ -125,6 +147,45 @@ func (c *derivationShowCommand) Run(ctx context.Context, g *globalConfig) error 
 	}
 	if len(results) == 0 {
 		return fmt.Errorf("no evaluation results")
+	}
+
+	if c.DOTFormat {
+		roots := make(map[string]*zbstore.Derivation, len(c.Args))
+		resultIndex := 0
+		for i := range c.Args {
+			if i < len(drvPaths) && drvPaths[i] != "" {
+				absolutePath, drv, err := parseDerivationFile(drvPaths[i])
+				if err != nil {
+					return err
+				}
+				roots[absolutePath] = drv
+				continue
+			}
+
+			result := results[resultIndex]
+			resultIndex++
+			drv, _ := result.(*frontend.Derivation)
+			if drv == nil {
+				return fmt.Errorf("%v is not a derivation", result)
+			}
+			roots[string(drv.Path)] = drv.Derivation
+		}
+
+		closeError := eval.Close()
+		evalClosed = true
+		if closeError != nil {
+			return closeError
+		}
+		closure, err := collectDerivationClosure(ctx, roots, func(ctx context.Context, paths []zbstore.Path) (map[zbstore.Path]*zbstore.Derivation, error) {
+			return loadLocalOrStoreDerivations(ctx, storeClient, di, paths)
+		})
+		if err != nil {
+			return err
+		}
+		if _, err := os.Stdout.Write(marshalDerivationDOT(closure)); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	resultIndex := 0
@@ -156,29 +217,41 @@ func (c *derivationShowCommand) Run(ctx context.Context, g *globalConfig) error 
 	return nil
 }
 
-func showDerivationFile(drvPath string, jsonFormat bool) ([]byte, error) {
+func parseDerivationFile(drvPath string) (string, *zbstore.Derivation, error) {
 	drvPath, err := filepath.Abs(drvPath)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	dir, err := zbstore.CleanDirectory(filepath.Dir(drvPath))
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	drvBytes, err := os.ReadFile(drvPath)
 	if err != nil {
-		return nil, err
-	}
-	if !jsonFormat {
-		// If we're not outputting JSON, no need to parse. Pass through, even if it's invalid.
-		return drvBytes, nil
+		return "", nil, err
 	}
 	drv, err := zbstore.ParseDerivation(dir, inferDerivationName(drvPath), drvBytes)
 	if err != nil {
-		return nil, fmt.Errorf("parse %s: %v", drvPath, err)
+		return "", nil, fmt.Errorf("parse %s: %v", drvPath, err)
+	}
+	return drvPath, drv, nil
+}
+
+func showDerivationFile(drvPath string, jsonFormat bool) ([]byte, error) {
+	if !jsonFormat {
+		// If we're not outputting JSON, no need to parse. Pass through, even if it's invalid.
+		absolutePath, err := filepath.Abs(drvPath)
+		if err != nil {
+			return nil, err
+		}
+		return os.ReadFile(absolutePath)
+	}
+	absolutePath, drv, err := parseDerivationFile(drvPath)
+	if err != nil {
+		return nil, err
 	}
 
-	jsonData, err := marshalDerivationJSON(drvPath, drv)
+	jsonData, err := marshalDerivationJSON(absolutePath, drv)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/zb/derivation_dot.go
+++ b/cmd/zb/derivation_dot.go
@@ -1,0 +1,223 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"maps"
+	"os"
+	"slices"
+
+	"zb.256lights.llc/pkg/internal/jsonrpc"
+	"zb.256lights.llc/pkg/internal/zbstorerpc"
+	"zb.256lights.llc/pkg/zbstore"
+	"zombiezen.com/go/nix/nar"
+)
+
+type derivationLoader func(context.Context, []zbstore.Path) (map[zbstore.Path]*zbstore.Derivation, error)
+
+func collectDerivationClosure(ctx context.Context, roots map[string]*zbstore.Derivation, load derivationLoader) (map[string]*zbstore.Derivation, error) {
+	closure := maps.Clone(roots)
+	for {
+		missingSet := make(map[zbstore.Path]struct{})
+		for _, drv := range closure {
+			for inputPath := range drv.InputDerivations {
+				if _, ok := closure[string(inputPath)]; !ok {
+					missingSet[inputPath] = struct{}{}
+				}
+			}
+		}
+		if len(missingSet) == 0 {
+			return closure, nil
+		}
+
+		missing := slices.Collect(maps.Keys(missingSet))
+		slices.Sort(missing)
+		loaded, err := load(ctx, missing)
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range missing {
+			drv := loaded[path]
+			if drv == nil {
+				return nil, fmt.Errorf("load derivation %s: %w", path, fs.ErrNotExist)
+			}
+			closure[string(path)] = drv
+		}
+	}
+}
+
+func loadLocalDerivations(_ context.Context, paths []zbstore.Path) (map[zbstore.Path]*zbstore.Derivation, error) {
+	result := make(map[zbstore.Path]*zbstore.Derivation, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(string(path))
+		if err != nil {
+			return nil, err
+		}
+		name, isDerivation := path.DerivationName()
+		if !isDerivation {
+			return nil, fmt.Errorf("%s is not a derivation", path)
+		}
+		drv, err := zbstore.ParseDerivation(path.Dir(), name, data)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %v", path, err)
+		}
+		result[path] = drv
+	}
+	return result, nil
+}
+
+func loadLocalOrStoreDerivations(ctx context.Context, storeClient jsonrpc.Handler, importer *zbstorerpc.DeferredImporter, paths []zbstore.Path) (map[zbstore.Path]*zbstore.Derivation, error) {
+	result := make(map[zbstore.Path]*zbstore.Derivation, len(paths))
+	var remotePaths []zbstore.Path
+	for _, path := range paths {
+		data, err := os.ReadFile(string(path))
+		if errors.Is(err, fs.ErrNotExist) {
+			remotePaths = append(remotePaths, path)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		name, isDerivation := path.DerivationName()
+		if !isDerivation {
+			return nil, fmt.Errorf("%s is not a derivation", path)
+		}
+		drv, err := zbstore.ParseDerivation(path.Dir(), name, data)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %v", path, err)
+		}
+		result[path] = drv
+	}
+	if len(remotePaths) == 0 {
+		return result, nil
+	}
+
+	receiver := &derivationExportReceiver{
+		derivations: make(map[zbstore.Path]*zbstore.Derivation, len(remotePaths)),
+	}
+	importer.SetImporter(zbstorerpc.NewReceiverImporter(receiver))
+	err := jsonrpc.Do(ctx, storeClient, zbstorerpc.ExportMethod, nil, &zbstorerpc.ExportRequest{
+		Paths:             remotePaths,
+		ExcludeReferences: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if receiver.err != nil {
+		return nil, receiver.err
+	}
+	maps.Copy(result, receiver.derivations)
+	return result, nil
+}
+
+type derivationExportReceiver struct {
+	buf         bytes.Buffer
+	derivations map[zbstore.Path]*zbstore.Derivation
+	err         error
+}
+
+func (r *derivationExportReceiver) Write(p []byte) (int, error) {
+	if r.err != nil {
+		return len(p), nil
+	}
+	return r.buf.Write(p)
+}
+
+func (r *derivationExportReceiver) ReceiveNAR(trailer *zbstore.ExportTrailer) {
+	defer r.buf.Reset()
+	if r.err != nil {
+		return
+	}
+
+	name, isDerivation := trailer.StorePath.DerivationName()
+	if !isDerivation {
+		r.err = fmt.Errorf("%s is not a derivation", trailer.StorePath)
+		return
+	}
+	nr := nar.NewReader(bytes.NewReader(r.buf.Bytes()))
+	header, err := nr.Next()
+	if err != nil {
+		r.err = fmt.Errorf("read %s: %v", trailer.StorePath, err)
+		return
+	}
+	if !header.Mode.IsRegular() {
+		r.err = fmt.Errorf("read %s: not a regular file", trailer.StorePath)
+		return
+	}
+	data, err := io.ReadAll(nr)
+	if err != nil {
+		r.err = fmt.Errorf("read %s: %v", trailer.StorePath, err)
+		return
+	}
+	if _, err := nr.Next(); err != io.EOF {
+		if err == nil {
+			r.err = fmt.Errorf("read %s: more than one file", trailer.StorePath)
+		} else {
+			r.err = fmt.Errorf("read %s: %v", trailer.StorePath, err)
+		}
+		return
+	}
+	drv, err := zbstore.ParseDerivation(trailer.StorePath.Dir(), name, data)
+	if err != nil {
+		r.err = fmt.Errorf("parse %s: %v", trailer.StorePath, err)
+		return
+	}
+	r.derivations[trailer.StorePath] = drv
+}
+
+func marshalDerivationDOT(derivations map[string]*zbstore.Derivation) []byte {
+	paths := slices.Collect(maps.Keys(derivations))
+	slices.Sort(paths)
+
+	var buf bytes.Buffer
+	buf.WriteString("digraph {\n")
+	buf.WriteString("\tgraph [ranksep=2.0];\n")
+	for _, path := range paths {
+		buf.WriteByte('\t')
+		appendDOTQuoted(&buf, path)
+		buf.WriteString(" [label=")
+		appendDOTQuoted(&buf, derivations[path].Name)
+		buf.WriteString(", shape=box];\n")
+	}
+	for _, path := range paths {
+		inputs := slices.Collect(maps.Keys(derivations[path].InputDerivations))
+		slices.Sort(inputs)
+		for _, inputPath := range inputs {
+			buf.WriteByte('\t')
+			appendDOTQuoted(&buf, path)
+			buf.WriteString(" -> ")
+			appendDOTQuoted(&buf, string(inputPath))
+			buf.WriteString(";\n")
+		}
+	}
+	buf.WriteString("}\n")
+	return buf.Bytes()
+}
+
+func appendDOTQuoted(buf *bytes.Buffer, s string) {
+	buf.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			buf.WriteString(`\\`)
+		case '"':
+			buf.WriteString(`\"`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '\t':
+			buf.WriteString(`\t`)
+		default:
+			fmt.Fprint(buf, string(r))
+		}
+	}
+	buf.WriteByte('"')
+}

--- a/cmd/zb/derivation_dot_test.go
+++ b/cmd/zb/derivation_dot_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"slices"
+	"testing"
+
+	"zb.256lights.llc/pkg/sets"
+	"zb.256lights.llc/pkg/zbstore"
+	"zombiezen.com/go/nix"
+	"zombiezen.com/go/nix/nar"
+)
+
+func TestCollectDerivationClosure(t *testing.T) {
+	const (
+		rootPath  = zbstore.Path("/opt/zb/store/00000000000000000000000000000000-root.drv")
+		childPath = zbstore.Path("/opt/zb/store/11111111111111111111111111111111-child.drv")
+		leafPath  = zbstore.Path("/opt/zb/store/22222222222222222222222222222222-leaf.drv")
+	)
+	all := map[zbstore.Path]*zbstore.Derivation{
+		rootPath: {
+			Name: "root",
+			InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+				childPath: sets.NewSorted("out"),
+			},
+		},
+		childPath: {
+			Name: "child",
+			InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+				leafPath: sets.NewSorted("out"),
+			},
+		},
+		leafPath: {
+			Name: "leaf",
+			InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+				rootPath: sets.NewSorted("out"),
+			},
+		},
+	}
+	var calls [][]zbstore.Path
+	load := func(_ context.Context, paths []zbstore.Path) (map[zbstore.Path]*zbstore.Derivation, error) {
+		calls = append(calls, slices.Clone(paths))
+		result := make(map[zbstore.Path]*zbstore.Derivation, len(paths))
+		for _, path := range paths {
+			result[path] = all[path]
+		}
+		return result, nil
+	}
+
+	got, err := collectDerivationClosure(context.Background(), map[string]*zbstore.Derivation{
+		string(rootPath): all[rootPath],
+	}, load)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPaths := slices.Sorted(maps.Keys(got)); !slices.Equal(gotPaths, []string{
+		string(rootPath),
+		string(childPath),
+		string(leafPath),
+	}) {
+		t.Errorf("closure paths = %q", gotPaths)
+	}
+	if len(calls) != 2 ||
+		!slices.Equal(calls[0], []zbstore.Path{childPath}) ||
+		!slices.Equal(calls[1], []zbstore.Path{leafPath}) {
+		t.Errorf("load calls = %q", calls)
+	}
+}
+
+func TestDerivationExportReceiver(t *testing.T) {
+	const drvPath = zbstore.Path("/opt/zb/store/00000000000000000000000000000000-example.drv")
+	want := &zbstore.Derivation{
+		Dir:     drvPath.Dir(),
+		Name:    "example",
+		System:  "x86_64-windows",
+		Builder: "builder",
+		Outputs: map[string]*zbstore.DerivationOutputType{
+			"out": zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
+		},
+	}
+	data, err := want.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var narData bytes.Buffer
+	nw := nar.NewWriter(&narData)
+	if err := nw.WriteHeader(&nar.Header{Size: int64(len(data))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := nw.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := nw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	receiver := &derivationExportReceiver{
+		derivations: make(map[zbstore.Path]*zbstore.Derivation),
+	}
+	if _, err := receiver.Write(narData.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	receiver.ReceiveNAR(&zbstore.ExportTrailer{StorePath: drvPath})
+	if receiver.err != nil {
+		t.Fatal(receiver.err)
+	}
+	got := receiver.derivations[drvPath]
+	if got == nil {
+		t.Fatal("receiver did not record derivation")
+	}
+	if got.Dir != want.Dir || got.Name != want.Name || got.System != want.System || got.Builder != want.Builder {
+		t.Errorf("received derivation = %#v; want %#v", got, want)
+	}
+}
+
+func TestMarshalDerivationDOT(t *testing.T) {
+	const (
+		rootPath  = "/opt/zb/store/00000000000000000000000000000000-root.drv"
+		childPath = "/opt/zb/store/11111111111111111111111111111111-child.drv"
+	)
+	got := string(marshalDerivationDOT(map[string]*zbstore.Derivation{
+		childPath: {Name: "child"},
+		rootPath: {
+			Name: `root "quoted"\name`,
+			InputDerivations: map[zbstore.Path]*sets.Sorted[string]{
+				childPath: sets.NewSorted("out"),
+			},
+		},
+	}))
+	want := "digraph {\n" +
+		"\tgraph [ranksep=2.0];\n" +
+		"\t\"" + rootPath + "\" [label=\"root \\\"quoted\\\"\\\\name\", shape=box];\n" +
+		"\t\"" + childPath + "\" [label=\"child\", shape=box];\n" +
+		"\t\"" + rootPath + "\" -> \"" + childPath + "\";\n" +
+		"}\n"
+	if got != want {
+		t.Errorf("marshalDerivationDOT() =\n%s\nwant:\n%s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- add `zb derivation show --dot` for GraphViz output
- recursively load input derivations from local files or the configured store
- de-duplicate cyclic/shared dependencies and emit deterministic nodes and edges
- add coverage for recursive loading, cycles, store-export parsing, ordering, and DOT escaping

Fixes #227

## Validation

- `go generate ./internal/ui`
- `go test -mod=readonly ./cmd/zb`
- `go test -mod=readonly -p=1 ./...`

The implementation and tests were reviewed and verified locally. The commit includes the repository-required `Assisted-by` trailer.
