### PR TITLE
s/out/t/ in `*zbstore.DerivationOutputType.FixedCA` method

### DIFF
--- a/zbstore/derivation.go
+++ b/zbstore/derivation.go
@@ -619,11 +619,11 @@ func (t *DerivationOutputType) HashType() (_ nix.HashType, ok bool) {
 
 // FixedCA returns a fixed hash output's content address.
 // ok is true only if the output was created by [FixedCAOutput].
-func (out *DerivationOutputType) FixedCA() (_ ContentAddress, ok bool) {
-	if !out.IsFixed() {
+func (t *DerivationOutputType) FixedCA() (_ ContentAddress, ok bool) {
+	if !t.IsFixed() {
 		return ContentAddress{}, false
 	}
-	return out.ca, true
+	return t.ca, true
 }
 
 // IsRecursiveFile reports whether the derivation output


### PR DESCRIPTION
Consistency with other methods.