### PR TITLE
Obtain build roots for derivations who have dependents that need the derivation's outputs

### DIFF
--- a/internal/backend/README.md
+++ b/internal/backend/README.md
@@ -23,8 +23,9 @@ When the backend receives a build request
 1. **Obtain build roots.**
    Walk the derivations in dependency order
    (i.e. derivations with no input derivations first).
-   When we encounter a derivation with outputs in the build request
-   or with missing realizations:
+   When we encounter a derivation with outputs in the build request,
+   a derivation with missing realizations,
+   or a derivation whose dependents are missing realizations:
 
    1. Check if we have the output store object(s) in the store.
       If so, mark as a build root and continue walking.

--- a/internal/backend/graph.go
+++ b/internal/backend/graph.go
@@ -19,6 +19,7 @@ import (
 
 // dependencyGraph stores indices of a set of derivations that are useful for realization.
 type dependencyGraph struct {
+	want sets.Set[zbstore.OutputReference]
 	// nodes is a map of .drv file path to [*dependencyGraphNode].
 	nodes map[zbstore.Path]*dependencyGraphNode
 	// roots is the set of .drv files that have no input derivations.
@@ -85,6 +86,7 @@ type dependencyGraphNode struct {
 // analyze produces a [dependencyGraph] for the given set of desired outputs.
 func analyze(derivations map[zbstore.Path]*zbstore.Derivation, want sets.Set[zbstore.OutputReference]) (*dependencyGraph, error) {
 	result := &dependencyGraph{
+		want:  want,
 		roots: make(sets.Set[zbstore.Path]),
 		nodes: make(map[zbstore.Path]*dependencyGraphNode),
 	}

--- a/internal/backend/graph_test.go
+++ b/internal/backend/graph_test.go
@@ -216,6 +216,19 @@ func TestAnalyze(t *testing.T) {
 
 			want := new(dependencyGraph)
 			*want = *test.want
+			want.want = make(sets.Set[zbstore.OutputReference])
+			for fakePath, outputNames := range test.desiredOutputs {
+				drvPath, err := pathForDrvName(maps.Keys(derivations), string(fakePath))
+				if err != nil {
+					t.Fatal("want.want:", err)
+				}
+				for outputName := range outputNames.All() {
+					want.want.Add(zbstore.OutputReference{
+						DrvPath:    drvPath,
+						OutputName: outputName,
+					})
+				}
+			}
 			want.nodes = make(map[zbstore.Path]*dependencyGraphNode)
 			for fakePath, node := range test.want.nodes {
 				drvPath, err := pathForDrvName(maps.Keys(derivations), string(fakePath))

--- a/internal/backend/realize.go
+++ b/internal/backend/realize.go
@@ -355,7 +355,7 @@ func (b *builder) realize(ctx context.Context, want sets.Set[zbstore.OutputRefer
 	if err := b.gatherRealizations(ctx, graph); err != nil {
 		return err
 	}
-	buildRoots, err := b.obtainBuildRoots(ctx, graph, want)
+	buildRoots, err := b.obtainBuildRoots(ctx, graph)
 	if err != nil {
 		return err
 	}
@@ -543,7 +543,7 @@ func (b *builder) gatherRealizationsForDerivation(ctx context.Context, curr zbst
 
 // obtainBuildRoots computes the set of derivations that can be used as a basis for building the rest of graph,
 // downloading store objects from the fallback store as needed.
-func (b *builder) obtainBuildRoots(ctx context.Context, graph *dependencyGraph, want sets.Set[zbstore.OutputReference]) (roots sets.Set[zbstore.Path], err error) {
+func (b *builder) obtainBuildRoots(ctx context.Context, graph *dependencyGraph) (roots sets.Set[zbstore.Path], err error) {
 	roots = make(sets.Set[zbstore.Path])
 	for it := graph.iterator(); ; {
 		curr, err := it.next(ctx)
@@ -554,33 +554,10 @@ func (b *builder) obtainBuildRoots(ctx context.Context, graph *dependencyGraph, 
 			return nil, err
 		}
 		log.Debugf(ctx, "Reached %v while obtaining build roots", curr)
-		node := graph.nodes[curr]
-		if node == nil {
-			return nil, fmt.Errorf("obtain build roots for %v: unknown derivation", curr)
+		processDependents, err := b.obtainBuildRootsForDerivation(ctx, graph, roots, curr)
+		if err != nil {
+			return nil, err
 		}
-
-		processDependents := true
-		for outputName := range node.usedOutputs {
-			ref := zbstore.OutputReference{
-				DrvPath:    curr,
-				OutputName: outputName.Value(),
-			}
-			// If this is one of the requested outputs, then we want to ensure the store objects exist locally
-			// or that we can get dependencies as close as possible.
-			// If we haven't recorded realizations for all of the outputs we need for the build,
-			// then we'll get dependencies as close as possible.
-			// (obtainBuildRootsForDerivation will start a BFS on the first iteration in this case.)
-			_, hasRealization := b.lookup(ref)
-			if want.Has(ref) || !hasRealization {
-				var err error
-				processDependents, err = b.obtainBuildRootsForDerivation(ctx, graph, roots, curr)
-				if err != nil {
-					return nil, err
-				}
-				break
-			}
-		}
-
 		it.finish(curr, processDependents)
 	}
 }
@@ -590,6 +567,14 @@ func (b *builder) obtainBuildRoots(ctx context.Context, graph *dependencyGraph, 
 // and attempt to download store objects matching their realizations if possible.
 // It reports whether the outputs of the derivation at drvPath are present in the local store.
 func (b *builder) obtainBuildRootsForDerivation(ctx context.Context, graph *dependencyGraph, roots sets.Set[zbstore.Path], drvPath zbstore.Path) (bool, error) {
+	node := graph.nodes[drvPath]
+	if node == nil {
+		return false, fmt.Errorf("obtain build roots for %s: unknown derivation", drvPath)
+	}
+	if !b.shouldObtainBuildRoots(graph, drvPath, node) {
+		return true, nil
+	}
+
 	log.Debugf(ctx, "Walking back from %s while obtaining build roots", drvPath)
 
 	conn, err := b.server.db.Get(ctx)
@@ -613,21 +598,16 @@ func (b *builder) obtainBuildRootsForDerivation(ctx context.Context, graph *depe
 		}
 		drvHashKey := makeHashKey(drvHash)
 		paths := make(map[zbstore.Path]sets.Set[equivalenceClass])
-		for handle := range node.usedOutputs {
-			eqClass := equivalenceClass{
-				drvHashKey: drvHashKey,
-				outputName: handle,
+		if b.allUsedRealizationsPresent(graph, curr) {
+			for handle := range node.usedOutputs {
+				eqClass := equivalenceClass{
+					drvHashKey: drvHashKey,
+					outputName: handle,
+				}
+				r := b.realizations[eqClass]
+				addToMultiMap(paths, r.path, eqClass)
 			}
-			r, ok := b.realizations[eqClass]
-			if !ok {
-				// If we don't have a realization for any used output,
-				// then we cannot use this as a build root.
-				goto descend
-			}
-			addToMultiMap(paths, r.path, eqClass)
-		}
 
-		{
 			err := b.server.copyFromFallback(ctx, conn, func(yield func(pathAndEquivalenceClass) bool) {
 				for path, eqClassesForPath := range paths {
 					for eqClass := range eqClassesForPath.All() {
@@ -648,7 +628,6 @@ func (b *builder) obtainBuildRootsForDerivation(ctx context.Context, graph *depe
 			log.Debugf(ctx, "Use %s as build root: %v", curr, err)
 		}
 
-	descend:
 		ignoreStack = append(ignoreStack, curr)
 		b.ignoreRealizations(graph, roots, &ignoreStack)
 		if len(node.derivation.InputDerivations) == 0 {
@@ -660,6 +639,63 @@ func (b *builder) obtainBuildRootsForDerivation(ctx context.Context, graph *depe
 	}
 
 	return false, nil
+}
+
+func (b *builder) shouldObtainBuildRoots(graph *dependencyGraph, drvPath zbstore.Path, node *dependencyGraphNode) bool {
+	for outputName := range node.usedOutputs {
+		// If this is one of the requested outputs, then we want to ensure the store objects exist locally
+		// or that we can get dependencies as close as possible.
+		ref := zbstore.OutputReference{
+			DrvPath:    drvPath,
+			OutputName: outputName.Value(),
+		}
+		if graph.want.Has(ref) {
+			return true
+		}
+	}
+
+	// If we haven't recorded realizations for all the outputs we need for the build,
+	// then we'll get dependencies as close as possible.
+	// (obtainBuildRootsForDerivation will start a BFS on the first iteration in this case.)
+	if !b.allUsedRealizationsPresent(graph, drvPath) {
+		return true
+	}
+	// If any dependent derivations are missing realizations needed for the build,
+	// then try to use this derivation as a build root.
+	// We may not visit the dependents if another part of the graph's realizations are ignored,
+	// so we preemptively walk.
+	// (See https://github.com/256lights/zb/issues/288)
+	for dependent := range node.dependents.All() {
+		if !b.allUsedRealizationsPresent(graph, dependent) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// allUsedRealizationsPresent reports whether all the outputs used for the derivation path in the graph
+// have realizations set.
+func (b *builder) allUsedRealizationsPresent(graph *dependencyGraph, drvPath zbstore.Path) bool {
+	node := graph.nodes[drvPath]
+	if node == nil {
+		return false
+	}
+	drvHash := b.drvHashes[drvPath]
+	if drvHash.IsZero() {
+		return false
+	}
+	drvHashKey := makeHashKey(drvHash)
+	for outputName := range node.usedOutputs {
+		eqClass := equivalenceClass{
+			drvHashKey: drvHashKey,
+			outputName: outputName,
+		}
+		if _, ok := b.realizations[eqClass]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (b *builder) ignoreRealizations(graph *dependencyGraph, roots sets.Set[zbstore.Path], drvPaths *[]zbstore.Path) {

--- a/internal/backend/realize_test.go
+++ b/internal/backend/realize_test.go
@@ -2029,6 +2029,101 @@ func TestRealizeMultiStepFallbackMissingObject(t *testing.T) {
 	checkSingleFileOutput(t, drv2Path, wantOutputPath2, []byte(wantOutputContent2), got)
 }
 
+// TestRealizeIssue288 is a regression test for https://github.com/256lights/zb/issues/288.
+func TestRealizeIssue288(t *testing.T) {
+	ctx := testcontext.New(t)
+	dir := backendtest.NewStoreDirectory(t)
+
+	exportArchive, err := txtar.ParseFile(filepath.Join("testdata", "TestRealizeIssue288.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects, err := storetest.TxtarObjects(dir, exportArchive.Files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partialDrvObject, err := findObjectWithName(derivationNameForCurrentSystem("bye2.txt"), slices.Values(objects))
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalDrvObject, err := findObjectWithName(derivationNameForCurrentSystem("final.txt"), slices.Values(objects))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exportBuffer := new(bytes.Buffer)
+	exporter := zbstore.NewExportWriter(exportBuffer)
+	for _, obj := range objects {
+		if err := exporter.WriteObject(ctx, obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := exporter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, client, err := backendtest.NewServer(ctx, t, dir, &backendtest.Options{
+		TempDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	codec, releaseCodec, err := storeCodec(ctx, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = codec.Export(nil, exportBuffer)
+	releaseCodec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	realizeResponse := new(zbstorerpc.RealizeResponse)
+	err = jsonrpc.Do(ctx, client, zbstorerpc.RealizeMethod, realizeResponse, &zbstorerpc.RealizeRequest{
+		DrvPaths: []zbstore.Path{partialDrvObject.StorePath},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backendtest.WaitForSuccessfulBuild(ctx, client, realizeResponse.BuildID); err != nil {
+		t.Errorf("build failed: %v", err)
+		for obj := range derivationsForCurrentSystem(slices.Values(objects)) {
+			gotLog, err := backendtest.ReadLog(ctx, client, realizeResponse.BuildID, obj.StorePath)
+			if err == nil {
+				t.Logf("log for %s:\n%s", obj.StorePath, gotLog)
+			}
+		}
+		t.FailNow()
+	}
+	realizeResponse = new(zbstorerpc.RealizeResponse)
+	err = jsonrpc.Do(ctx, client, zbstorerpc.RealizeMethod, realizeResponse, &zbstorerpc.RealizeRequest{
+		DrvPaths: []zbstore.Path{finalDrvObject.StorePath},
+		Reuse:    &zbstorerpc.ReusePolicy{All: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := backendtest.WaitForSuccessfulBuild(ctx, client, realizeResponse.BuildID)
+	if err != nil {
+		t.Errorf("build failed: %v", err)
+		for obj := range derivationsForCurrentSystem(slices.Values(objects)) {
+			gotLog, err := backendtest.ReadLog(ctx, client, realizeResponse.BuildID, obj.StorePath)
+			if err == nil {
+				t.Logf("log for %s:\n%s", obj.StorePath, gotLog)
+			}
+		}
+		t.FailNow()
+	}
+
+	wantOutputContent := strings.Repeat("Hello, World!\n", 4) + strings.Repeat("Good-bye\n", 2)
+	finalDrvOutputName, _ := finalDrvObject.StorePath.DerivationName()
+	wantOutputPath, err := singleFileOutputPath(dir, finalDrvOutputName, []byte(wantOutputContent), zbstore.References{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSingleFileOutput(t, finalDrvObject.StorePath, wantOutputPath, []byte(wantOutputContent), got)
+}
+
 func TestRealizeUpload(t *testing.T) {
 	ctx := testcontext.New(t)
 	dir := backendtest.NewStoreDirectory(t)
@@ -2307,6 +2402,21 @@ func derivationNameForCurrentSystem(name string) string {
 		suffixStart = len(name)
 	}
 	return name[:suffixStart] + "-" + system.Current().String() + name[suffixStart:] + zbstore.DerivationExt
+}
+
+func derivationsForCurrentSystem[O zbstore.Object](objects iter.Seq[O]) iter.Seq[O] {
+	systemString := "-" + system.Current().String()
+	return func(yield func(O) bool) {
+		for obj := range objects {
+			name := obj.Trailer().StorePath.Name()
+			if !strings.Contains(name, systemString) || !strings.HasSuffix(name, zbstore.DerivationExt) {
+				continue
+			}
+			if !yield(obj) {
+				return
+			}
+		}
+	}
 }
 
 func findObjectWithName[O zbstore.Object](name string, objects iter.Seq[O]) (O, error) {

--- a/internal/backend/testdata/TestRealizeIssue288.txt
+++ b/internal/backend/testdata/TestRealizeIssue288.txt
@@ -1,0 +1,400 @@
+Build graph that is large enough to replicate https://github.com/256lights/zb/issues/288.
+
+-- 9vx0ap4n2lpv5gxsb655vx6l4d92l65h-hello-x86_64-linux.txt.drv --
+Derive(
+  [("out", "", "r:sha256", "")],
+  [],
+  [],
+  "x86_64-unknown-linux",
+  "/bin/sh",
+  ["-c","echo 'Hello, World!' > $out"],
+  [
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- fmw7jw6az4b9awgfyfnxwjdvgmysw9r5-hello-aarch64-linux.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [],
+  "aarch64-linux",
+  "/bin/sh",
+  [
+    "-c",
+    "echo 'Hello, World!' > $out"
+  ],
+  [
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- iig0kq9qmld6d20h1i9njvny879jb67h-hello-aarch64-apple-macos.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [],
+  "aarch64-apple-macos",
+  "/bin/sh",
+  [
+    "-c",
+    "echo 'Hello, World!' > $out"
+  ],
+  [
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- yf81wgl5mizi79sgz57x5qv6gypyv5cn-hello-x86_64-pc-windows.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [],
+  "x86_64-pc-windows",
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  [
+    "-Command",
+    "Out-File -InputObject \"Hello, World!`n\" -NoNewline -Encoding ascii -FilePath ${env:out}"
+  ],
+  [
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- xdp9xdmj863wmjcmkklqnw1zjng5y4a2-hello2-x86_64-linux.txt.drv --
+Derive(
+  [("out", "", "r:sha256", "")],
+  [
+    ("/opt/zb/store/9vx0ap4n2lpv5gxsb655vx6l4d92l65h-hello-x86_64-linux.txt.drv", ["out"])
+  ],
+  [],
+  "x86_64-unknown-linux",
+  "/bin/sh",
+  ["-c","while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"],
+  [
+    ("in", "/0ypmfyr6krqfbq68v18q1yhmqfmfm7grszwczpbggv4vdgabzd79"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- 91794yh4q5kfm3vyhqrlm7kk6261pw62-hello2-aarch64-linux.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("/opt/zb/store/fmw7jw6az4b9awgfyfnxwjdvgmysw9r5-hello-aarch64-linux.txt.drv", ["out"])
+  ],
+  [],
+  "aarch64-linux",
+  "/bin/sh",
+  [
+    "-c",
+    "while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"
+  ],
+  [
+    ("in", "/0csvnmiqc2s50szq1mbfrfr1m9sdrg27nrly395j8j7sjns6zl07"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- hbl8h5lgswz8dwavrlpnxsk87mmnsjy0-hello2-aarch64-apple-macos.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("/opt/zb/store/iig0kq9qmld6d20h1i9njvny879jb67h-hello-aarch64-apple-macos.txt.drv", ["out"])
+  ],
+  [],
+  "aarch64-apple-macos",
+  "/bin/sh",
+  [
+    "-c",
+    "while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"
+  ],
+  [
+    ("in", "/03chkd7yjqpz9hw4vs8636c3im5z8ii534qwsm5srz1pzjw6w2lj"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- wm1qj7haz2z2fp1ah18q0y0igm4vpqfw-hello2-x86_64-pc-windows.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("C:\\zb\\store\\yf81wgl5mizi79sgz57x5qv6gypyv5cn-hello-x86_64-pc-windows.txt.drv", ["out"])
+  ],
+  [],
+  "x86_64-pc-windows",
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  [
+    "-Command",
+    "$x = Get-Content -Raw ${env:in} ; ($x + $x) | Out-File -NoNewline -Encoding ascii -FilePath ${env:out}"
+  ],
+  [
+    ("in", "/0iz56lmsxkx1g00xmfj4r0wlv64sxzvprfy4mfmszrfcm7l4345g"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- l8lk7nq77yvh4x3nwqbj5sdhicw5fcfr-hello4-x86_64-linux.txt.drv --
+Derive(
+  [("out", "", "r:sha256", "")],
+  [
+    ("/opt/zb/store/xdp9xdmj863wmjcmkklqnw1zjng5y4a2-hello2-x86_64-linux.txt.drv", ["out"])
+  ],
+  [],
+  "x86_64-unknown-linux",
+  "/bin/sh",
+  ["-c","while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"],
+  [
+    ("in", "/03aqn181ihw8cjkfpfxpx1wkhrgv9p01xxp77wawycdqwg7288zf"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- y1mp6jscn0pncxpyl92rp9rjd2j7bx73-hello4-aarch64-linux.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("/opt/zb/store/91794yh4q5kfm3vyhqrlm7kk6261pw62-hello2-aarch64-linux.txt.drv", ["out"])
+  ],
+  [],
+  "aarch64-linux",
+  "/bin/sh",
+  [
+    "-c",
+    "while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"
+  ],
+  [
+    ("in", "/0vrk8178j5x6rw6d3fpwh72fd31gp5s7fqzakqzs6iw383y7i5rk"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- 79vcf1kqisjirha79d5y32qgdgn5103y-hello4-aarch64-apple-macos.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("/opt/zb/store/hbl8h5lgswz8dwavrlpnxsk87mmnsjy0-hello2-aarch64-apple-macos.txt.drv", ["out"])
+  ],
+  [],
+  "aarch64-apple-macos",
+  "/bin/sh",
+  [
+    "-c",
+    "while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"
+  ],
+  [
+    ("in", "/102h2pvxk1gvrwydm66j6k8a29l2cwic2pxx14h3p1mf4i5wyhmk"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- vij2bxvz5s0j2msgjfnv9g2vnfi1n2fl-hello4-x86_64-pc-windows.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("C:\\zb\\store\\wm1qj7haz2z2fp1ah18q0y0igm4vpqfw-hello2-x86_64-pc-windows.txt.drv", ["out"])
+  ],
+  [],
+  "x86_64-pc-windows",
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  [
+    "-Command",
+    "$x = Get-Content -Raw ${env:in} ; ($x + $x) | Out-File -NoNewline -Encoding ascii -FilePath ${env:out}"
+  ],
+  [
+    ("in", "/1icfmsavy11w28x9c05y8pma7s3inkz77mkljqa4h0lc89a6x2nl"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- 98rbkkjrk660n3v7bfvpgyl31hzfikc2-bye-x86_64-linux.txt.drv --
+Derive(
+  [("out", "", "r:sha256", "")],
+  [],
+  [],
+  "x86_64-unknown-linux",
+  "/bin/sh",
+  ["-c","echo 'Good-bye' > $out"],
+  [
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- 67w04g06pkp274b1b5ppypifg0ys96ix-bye-aarch64-linux.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [],
+  "aarch64-linux",
+  "/bin/sh",
+  [
+    "-c",
+    "echo 'Good-bye' > $out"
+  ],
+  [
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- 53rilghb8szpc1fg4cznyq0flvfzg7zm-bye-aarch64-apple-macos.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [],
+  "aarch64-apple-macos",
+  "/bin/sh",
+  [
+    "-c",
+    "echo 'Good-bye' > $out"
+  ],
+  [
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- l3bwyiswnxsjkfr66v5b5vbpq5pdrg2y-bye-x86_64-pc-windows.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [],
+  "x86_64-pc-windows",
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  [
+    "-Command",
+    "Out-File -InputObject \"Good-bye`n\" -NoNewline -Encoding ascii -FilePath ${env:out}"
+  ],
+  [
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- vz89da3z628n94w7wgfrsyapgr3wjcjh-bye2-x86_64-linux.txt.drv --
+Derive(
+  [("out", "", "r:sha256", "")],
+  [
+    ("/opt/zb/store/98rbkkjrk660n3v7bfvpgyl31hzfikc2-bye-x86_64-linux.txt.drv", ["out"])
+  ],
+  [],
+  "x86_64-unknown-linux",
+  "/bin/sh",
+  ["-c","while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"],
+  [
+    ("in", "/10wj9fsi5m229xcp2qhy7igzy767ih7ankb8w0xg47w2lh4pg8dj"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- rfaij2rp5gahmzlyr4wrw2m43cdpmjl0-bye2-aarch64-linux.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("/opt/zb/store/67w04g06pkp274b1b5ppypifg0ys96ix-bye-aarch64-linux.txt.drv", ["out"])
+  ],
+  [],
+  "aarch64-linux",
+  "/bin/sh",
+  [
+    "-c",
+    "while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"
+  ],
+  [
+    ("in", "/12waw4c2r2wj95m2ndf0pkcz5w923l6jjajp4ln27gvh5n9kv2sh"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- 6p6bm5z98bcnxj30l59xa2gpij47hyrw-bye2-aarch64-apple-macos.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("/opt/zb/store/53rilghb8szpc1fg4cznyq0flvfzg7zm-bye-aarch64-apple-macos.txt.drv", ["out"])
+  ],
+  [],
+  "aarch64-apple-macos",
+  "/bin/sh",
+  [
+    "-c",
+    "while read line; do echo \"$line\"; done < $in > $out; while read line; do echo \"$line\"; done < $in >> $out"
+  ],
+  [
+    ("in", "/1zp6ddnw5mj1wgnx1fm95s86pzh23sawzlarj81339jz1b5vsm2l"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- f7q72f9sqcbkh8br8mf11jd8d3sgisl2-bye2-x86_64-pc-windows.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("C:\\zb\\store\\l3bwyiswnxsjkfr66v5b5vbpq5pdrg2y-bye-x86_64-pc-windows.txt.drv", ["out"])
+  ],
+  [],
+  "x86_64-pc-windows",
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  [
+    "-Command",
+    "$x = Get-Content -Raw ${env:in} ; ($x + $x) | Out-File -NoNewline -Encoding ascii -FilePath ${env:out}"
+  ],
+  [
+    ("in", "/05y5j30f109jnq80lhym3p5ch8rl7a4m6a1pwz8vic1qfn64fk0y"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- iw98ygpnzfydzdi2pw7rzmklqsvn1vb2-final-x86_64-linux.txt.drv --
+Derive(
+  [("out", "", "r:sha256", "")],
+  [
+    ("/opt/zb/store/l8lk7nq77yvh4x3nwqbj5sdhicw5fcfr-hello4-x86_64-linux.txt.drv", ["out"]),
+    ("/opt/zb/store/vz89da3z628n94w7wgfrsyapgr3wjcjh-bye2-x86_64-linux.txt.drv", ["out"])
+  ],
+  [],
+  "x86_64-unknown-linux",
+  "/bin/sh",
+  ["-c","while read line; do echo \"$line\"; done < $in1 >> $out; while read line; do echo \"$line\"; done < $in2 >> $out"],
+  [
+    ("in1", "/0kahkvim0kqj524m258qi83jc6y60j0dcbqgxvrvrf8ba4h85611"),
+    ("in2", "/10f2dadv5isiscwzk6sqfmhkps7g4qhv067bijmslnwh69gwmdrj"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- p9dyf459lm32qk5ybpwxih90l75ywy9i-final-aarch64-linux.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("/opt/zb/store/rfaij2rp5gahmzlyr4wrw2m43cdpmjl0-bye2-aarch64-linux.txt.drv", ["out"]),
+    ("/opt/zb/store/y1mp6jscn0pncxpyl92rp9rjd2j7bx73-hello4-aarch64-linux.txt.drv", ["out"])
+  ],
+  [],
+  "aarch64-linux",
+  "/bin/sh",
+  [
+    "-c",
+    "while read line; do echo \"$line\"; done < $in1 >> $out; while read line; do echo \"$line\"; done < $in2 >> $out"
+  ],
+  [
+    ("in1", "/0jlmarw67248ry4b6xnaq2wm4az2l5vyny8skcxqlzkb4bk6pqfl"),
+    ("in2", "/0wad33jk6r8xqik957vpb0bcwq8nlm5ikh4hb1fz834kk9sdwg92"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- bkbn4rx0rar5qiw2h22k60bf5zvzyr9a-final-aarch64-apple-macos.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("/opt/zb/store/6p6bm5z98bcnxj30l59xa2gpij47hyrw-bye2-aarch64-apple-macos.txt.drv", ["out"]),
+    ("/opt/zb/store/79vcf1kqisjirha79d5y32qgdgn5103y-hello4-aarch64-apple-macos.txt.drv", ["out"])
+  ],
+  [],
+  "aarch64-apple-macos",
+  "/bin/sh",
+  [
+    "-c",
+    "while read line; do echo \"$line\"; done < $in1 >> $out; while read line; do echo \"$line\"; done < $in2 >> $out"
+  ],
+  [
+    ("in1", "/1f5hncxxfgmgaz467fqcwdcmgl3pvhqvjbi8kvp09a6diqnlpcq8"),
+    ("in2", "/1biaml1q2nm42vp56nfjx9ymq2hspxnza2q6z4ymn10ccc6d3kwv"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- 1mbda5cb2jgjqk5d929p7lbq4859xp3p-final-x86_64-pc-windows.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [
+    ("C:\\zb\\store\\f7q72f9sqcbkh8br8mf11jd8d3sgisl2-bye2-x86_64-pc-windows.txt.drv", ["out"]),
+    ("C:\\zb\\store\\vij2bxvz5s0j2msgjfnv9g2vnfi1n2fl-hello4-x86_64-pc-windows.txt.drv", ["out"])
+  ],
+  [],
+  "x86_64-pc-windows",
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  [
+    "-Command",
+    "$x = Get-Content -Raw ${env:in1} ; $y = Get-Content -Raw ${env:in2} ; ($x + $y) | Out-File -NoNewline -Encoding ascii -FilePath ${env:out}"
+  ],
+  [
+    ("in1", "/11cywx92d47d7a5l1wrgcxiw1q9ax0ws900x5qz6fq38y2kx5ms0"),
+    ("in2", "/0ys8d5ncqv73h32fqvp7lqjqw97245q9n9fy81rbc8h5zn7rrhp9"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)


### PR DESCRIPTION
Addresses an issue where realization would not walk the entire graph for certain incremental builds.

Fixes #288