### PR TITLE
Provide more details for errors with unexpected HTTP responses

### DIFF
--- a/internal/backend/builtin.go
+++ b/internal/backend/builtin.go
@@ -22,6 +22,7 @@ import (
 
 	"zb.256lights.llc/pkg/internal/osutil"
 	"zb.256lights.llc/pkg/internal/useragent"
+	"zb.256lights.llc/pkg/internal/xhttp"
 	"zb.256lights.llc/pkg/zbstore"
 	"zombiezen.com/go/log"
 )
@@ -79,7 +80,7 @@ func fetchURL(ctx context.Context, drv *zbstore.Derivation, realStoreDir string)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s returned HTTP %s", href, resp.Status)
+		return fmt.Errorf("get %s: %v", href, xhttp.ErrorFromResponse(resp))
 	}
 	perm := os.FileMode(0o644)
 	if executable {

--- a/internal/frontend/urls.go
+++ b/internal/frontend/urls.go
@@ -20,6 +20,7 @@ import (
 	"zb.256lights.llc/pkg/internal/lua"
 	"zb.256lights.llc/pkg/internal/lualex"
 	"zb.256lights.llc/pkg/internal/system"
+	"zb.256lights.llc/pkg/internal/xhttp"
 	"zb.256lights.llc/pkg/internal/xio"
 	"zb.256lights.llc/pkg/sets"
 	"zb.256lights.llc/pkg/zbstore"
@@ -186,7 +187,7 @@ func (eval *Eval) importURL(ctx context.Context, u *url.URL) (zbstore.Path, erro
 	respCloser := xio.CloseOnce(resp.Body)
 	defer respCloser.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("download %v: http %s", u, resp.Status)
+		return "", fmt.Errorf("download %v: %v", u, xhttp.ErrorFromResponse(resp))
 	}
 
 	// If the server provides a Content-Length header,

--- a/internal/xhttp/http_error.go
+++ b/internal/xhttp/http_error.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package xhttp
+
+import (
+	"bytes"
+	"cmp"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+type httpError struct {
+	response  http.Response
+	body      []byte
+	bodyError error
+}
+
+// ErrorFromResponse turns an [*http.Response] into an error.
+// The error message will include the HTTP status code
+// and the body if ErrorFromResponse deems it is text.
+func ErrorFromResponse(resp *http.Response) error {
+	body, bodyError := io.ReadAll(http.MaxBytesReader(nil, resp.Body, 256<<10)) // 256 KiB
+	// Clone after read so we potentially get Trailer.
+	resp = cloneResponse(resp)
+	resp.Body = nil
+	err := &httpError{
+		response:  *resp,
+		body:      body,
+		bodyError: bodyError,
+	}
+	if 100 <= resp.StatusCode && resp.StatusCode < 400 {
+		return fmt.Errorf("unexpected %w", err)
+	}
+	return err
+}
+
+func (e *httpError) Error() string {
+	sb := new(strings.Builder)
+	sb.WriteString("http ")
+	sb.WriteString(cmp.Or(e.response.Status, Status(e.response.StatusCode)))
+
+	if body := bytes.TrimRight(e.body, "\n\r"); len(body) > 0 && !bytes.ContainsAny(body, "\x00") {
+		if bytes.ContainsAny(body, "\n\r") {
+			sb.WriteString(":\n")
+		} else {
+			sb.WriteString(": ")
+		}
+		// Remove carriage returns and replace with newlines where necessary.
+		sb.Grow(len(body))
+		for i, b := range body {
+			switch {
+			case b == '\r' && !(i+1 < len(body) && body[i+1] == '\n'):
+				sb.WriteByte('\n')
+			case b != '\r':
+				sb.WriteByte(b)
+			}
+		}
+		if _, truncated := errors.AsType[*http.MaxBytesError](e.bodyError); truncated {
+			sb.WriteString("(...)")
+		}
+	}
+
+	return sb.String()
+}
+
+// ErrorStatusCode returns the status code of an error created by [ErrorFromResponse]
+// and reports whether the error is or wraps an error created by [ErrorFromResponse].
+// If the error is nil, then ErrorStatusCode returns (200 (OK), false).
+// If the error was not created by [ErrorFromResponse],
+// then ErrorStatusCode returns (500 (Internal Server Error), false).
+func ErrorStatusCode(err error) (statusCode int, ok bool) {
+	if err == nil {
+		return http.StatusOK, false
+	}
+	h, ok := errors.AsType[*httpError](err)
+	if !ok {
+		return http.StatusInternalServerError, false
+	}
+	return h.response.StatusCode, true
+}
+
+// ResponseFromError returns a copy of the response passed to [ErrorFromResponse].
+// ResponseFromError returns (nil, false) if the error is not an error created by [ErrorFromResponse]
+// or an error that wraps such an error.
+// The Body field of the response does not need to be closed.
+func ResponseFromError(err error) (_ *http.Response, ok bool) {
+	h, ok := errors.AsType[*httpError](err)
+	if !ok {
+		return nil, false
+	}
+	resp := cloneResponse(&h.response)
+	var body io.Reader = bytes.NewReader(h.body)
+	if h.bodyError != nil {
+		body = io.MultiReader(body, errorReader{h.bodyError})
+	}
+	resp.Body = io.NopCloser(body)
+	return resp, true
+}
+
+func cloneResponse(r *http.Response) *http.Response {
+	r = new(*r)
+	r.Header = r.Header.Clone()
+	r.Trailer = r.Trailer.Clone()
+	r.TransferEncoding = slices.Clone(r.TransferEncoding)
+	return r
+}
+
+type errorReader struct {
+	err error
+}
+
+func (er errorReader) Read(p []byte) (int, error) {
+	return 0, er.err
+}
+
+func (er errorReader) WriteTo(w io.Writer) (int64, error) {
+	return 0, er.err
+}

--- a/internal/zbstorehttp/http.go
+++ b/internal/zbstorehttp/http.go
@@ -76,7 +76,7 @@ func fetch(ctx context.Context, client Client, req *fetchRequest) (*fetchRespons
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch %v: %w", req.url.Redacted(), httpErrorFromResponse(resp))
+		return nil, fmt.Errorf("fetch %v: %w", req.url.Redacted(), xhttp.ErrorFromResponse(resp))
 	}
 
 	result := &fetchResponse{
@@ -322,7 +322,7 @@ func putEncoding(ctx context.Context, client Client, contentEncoding string, req
 		resp.StatusCode != http.StatusOK &&
 		resp.StatusCode != http.StatusCreated &&
 		resp.StatusCode != http.StatusNoContent {
-		err = httpErrorFromResponse(resp)
+		err = xhttp.ErrorFromResponse(resp)
 	}
 	if err != nil {
 		return fmt.Errorf("put %s: %w", req.url.Redacted(), err)
@@ -379,8 +379,8 @@ func requestNegotiationFromFetchResponse(resp *fetchResponse, err error) *reques
 	if resp != nil {
 		return &resp.requestNegotiation
 	}
-	if h, ok := errors.AsType[*httpError](err); ok {
-		return &h.requestNegotiation
+	if resp, ok := xhttp.ResponseFromError(err); ok {
+		return requestNegotiationFromResponseHeader(resp.Header)
 	}
 	return nil
 }
@@ -389,55 +389,15 @@ func (rn *requestNegotiation) isMethodAllowed(method string) bool {
 	return rn == nil || rn.allow == nil || rn.allow.Has(method)
 }
 
-type httpError struct {
-	statusCode         int
-	status             string
-	requestNegotiation requestNegotiation
-}
-
-func httpErrorFromResponse(resp *http.Response) error {
-	err := &httpError{
-		statusCode:         resp.StatusCode,
-		status:             cmp.Or(resp.Status, xhttp.Status(resp.StatusCode)),
-		requestNegotiation: *requestNegotiationFromResponseHeader(resp.Header),
-	}
-	if 100 <= resp.StatusCode && resp.StatusCode < 400 {
-		return fmt.Errorf("unexpected %w", err)
-	}
-	return err
-}
-
-func (e *httpError) Error() string {
-	status := e.status
-	if status == "" {
-		status = http.StatusText(e.statusCode)
-		if status == "" {
-			status = strconv.Itoa(e.statusCode)
-		}
-	}
-	return "http " + status
-}
-
-func errorStatusCode(err error) (statusCode int, ok bool) {
-	if err == nil {
-		return http.StatusOK, false
-	}
-	var h *httpError
-	if !errors.As(err, &h) {
-		return http.StatusInternalServerError, false
-	}
-	return h.statusCode, true
-}
-
 func isNotFound(err error) bool {
-	code, _ := errorStatusCode(err)
+	code, _ := xhttp.ErrorStatusCode(err)
 	return code == http.StatusNotFound || code == http.StatusGone
 }
 
 // isClientError reports whether the error indicates a client fault
 // and should not be retried.
 func isClientError(err error) bool {
-	code, _ := errorStatusCode(err)
+	code, _ := xhttp.ErrorStatusCode(err)
 	return 400 <= code && code < 500 &&
 		code != http.StatusRequestTimeout &&
 		code != http.StatusPreconditionFailed &&
@@ -448,7 +408,7 @@ func isClientError(err error) bool {
 // due to an unsupported Content-Encoding header,
 // and if so, returns the values of the Accept-Encoding header field.
 func isUnsupportedContentCoding(err error) (acceptEncoding []string, ok bool) {
-	h, ok := errors.AsType[*httpError](err)
+	resp, ok := xhttp.ResponseFromError(err)
 	if !ok {
 		return nil, false
 	}
@@ -457,10 +417,11 @@ func isUnsupportedContentCoding(err error) (acceptEncoding []string, ok bool) {
 	// MUST NOT include the Accept-Encoding header field."
 	//
 	// [RFC 9110 Section 12.5.3]: https://datatracker.ietf.org/doc/html/rfc9110#section-12.5.3
-	if h.statusCode != http.StatusUnsupportedMediaType || len(h.requestNegotiation.acceptEncoding) == 0 {
+	acceptEncoding = resp.Header.Values("Accept-Encoding")
+	if resp.StatusCode != http.StatusUnsupportedMediaType || len(acceptEncoding) == 0 {
 		return nil, false
 	}
-	return h.requestNegotiation.acceptEncoding, true
+	return acceptEncoding, true
 }
 
 type methodNotAllowedError struct {
@@ -475,7 +436,7 @@ func isMethodNotAllowed(err error) bool {
 	if _, ok := errors.AsType[methodNotAllowedError](err); ok {
 		return true
 	}
-	code, _ := errorStatusCode(err)
+	code, _ := xhttp.ErrorStatusCode(err)
 	return code == http.StatusMethodNotAllowed || code == http.StatusNotImplemented
 }
 

--- a/internal/zbstorehttp/zbstorehttp.go
+++ b/internal/zbstorehttp/zbstorehttp.go
@@ -77,7 +77,7 @@ func (s *Store) discover(ctx context.Context) (*hal.Resource, error) {
 		accept: "application/hal+json,application/json;q=0.9,text/*;q=0.8,*/*;q=0.7",
 	})
 	if err != nil {
-		code, _ := errorStatusCode(err)
+		code, _ := xhttp.ErrorStatusCode(err)
 		err := fmt.Errorf("get discovery document: %v", err)
 		if code == http.StatusGone {
 			// Gone indicates that retries to obtain this resource will continue to fail.
@@ -409,7 +409,7 @@ func (obj *httpObject) WriteNAR(ctx context.Context, dst io.Writer) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		err := httpErrorFromResponse(resp)
+		err := xhttp.ErrorFromResponse(resp)
 		return fmt.Errorf("download %s: get %s: %v", obj.info.StorePath, narFileURL.Redacted(), err)
 	}
 	decodedBody, err := httpencoding.Decode(resp.Body, resp.Header.Get("Content-Encoding"))


### PR DESCRIPTION
Moved functionality to `internal/xhttp` so all HTTP error messages are consistent. Now will read the body (up to a reasonable limit) and display it to the user to assist in troubleshooting issues.