### PR TITLE
Ensure connection is closed in `backendtest.NewServer`

### DIFF
--- a/internal/backendtest/backendtest.go
+++ b/internal/backendtest/backendtest.go
@@ -13,12 +13,14 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"zb.256lights.llc/pkg/bytebuffer"
 	"zb.256lights.llc/pkg/internal/backend"
 	"zb.256lights.llc/pkg/internal/jsonrpc"
+	"zb.256lights.llc/pkg/internal/xio"
 	"zb.256lights.llc/pkg/internal/zbstorerpc"
 	"zb.256lights.llc/pkg/zbstore"
 )
@@ -113,13 +115,20 @@ func NewServer(ctx context.Context, tb TB, storeDir zbstore.Directory, opts *Opt
 	serverCodec := zbstorerpc.NewCodec(serverConn, &zbstorerpc.CodecOptions{
 		Importer: zbstorerpc.NewReceiverImporter(serverReceiver),
 	})
+	serverCodecCloser := xio.CloseOnce(serverCodec)
+	stopServerCodecClose := context.AfterFunc(serveCtx, func() {
+		serverCodecCloser.Close()
+	})
 	wg.Go(func() {
 		jsonrpc.Serve(backend.WithExporter(serveCtx, serverCodec), serverCodec, srv)
-		serverCodec.Close()
+		stopServerCodecClose()
+		serverCodecCloser.Close()
 	})
 
 	clientCodec := zbstorerpc.NewCodec(clientConn, &opts.ClientOptions)
+	var usedClientCodec atomic.Bool
 	client := jsonrpc.NewClient(func(ctx context.Context) (jsonrpc.ClientCodec, error) {
+		usedClientCodec.Store(true)
 		return clientCodec, nil
 	})
 
@@ -127,6 +136,12 @@ func NewServer(ctx context.Context, tb TB, storeDir zbstore.Directory, opts *Opt
 		if err := client.Close(); err != nil {
 			tb.Logf("client.Close: %v", err)
 			tb.Fail()
+		}
+		if !usedClientCodec.Load() {
+			if err := clientCodec.Close(); err != nil {
+				tb.Logf("client.Close: %v", err)
+				tb.Fail()
+			}
 		}
 
 		stopServe()

--- a/internal/xio/xio.go
+++ b/internal/xio/xio.go
@@ -4,7 +4,10 @@
 // Package xio provides I/O utilities.
 package xio
 
-import "io"
+import (
+	"io"
+	"sync"
+)
 
 // A WriteCounter counts the number of bytes written to it.
 type WriteCounter int64
@@ -22,22 +25,16 @@ func (wc *WriteCounter) WriteString(s string) (n int, err error) {
 }
 
 type onceCloser struct {
-	c      io.Closer
-	err    error
-	closed bool
+	f func() error
 }
 
 // CloseOnce returns an [io.Closer] that calls c at most once.
 func CloseOnce(c io.Closer) io.Closer {
-	return &onceCloser{c: c}
+	return &onceCloser{f: sync.OnceValue(c.Close)}
 }
 
 func (oc *onceCloser) Close() error {
-	if !oc.closed {
-		oc.err = oc.c.Close()
-		oc.closed = true
-	}
-	return oc.err
+	return oc.f()
 }
 
 type emptyReader struct{}


### PR DESCRIPTION
For tests that create a server but not make RPCs to it, then the client may never "open" the singular client codec. In this case, the cleanup in `backendtest.NewServer` must close the client codec or else the test deadlocks.

Fixes #151