### PR TITLE
Fix bad realization serialization for store objects with references to sources

### DIFF
--- a/internal/backend/backend_store.go
+++ b/internal/backend/backend_store.go
@@ -280,19 +280,19 @@ func recordRealizations(conn *sqlite.Conn, realizations iter.Seq2[zbstore.Realiz
 			}
 
 			refClassStmt.SetText(":reference_path", string(rc.Path))
-			if !rc.Realization.Valid {
+			if rc.Realization.IsZero() {
 				refClassStmt.SetNull(":reference_drv_hash_algorithm")
 				refClassStmt.SetNull(":reference_drv_hash_bits")
 				refClassStmt.SetNull(":reference_output_name")
 			} else {
-				h := rc.Realization.X.DerivationHash
+				h := rc.Realization.DerivationHash
 				if err := upsertDrvHash(conn, h); err != nil {
 					return fmt.Errorf("record realization for %v: reference %s: %v", ref, rc.Path, err)
 				}
 
 				refClassStmt.SetText(":reference_drv_hash_algorithm", h.Type().String())
 				refClassStmt.SetBytes(":reference_drv_hash_bits", h.Bytes(nil))
-				refClassStmt.SetText(":reference_output_name", rc.Realization.X.OutputName)
+				refClassStmt.SetText(":reference_output_name", rc.Realization.OutputName)
 			}
 
 			if _, err := refClassStmt.Step(); err != nil {
@@ -795,7 +795,7 @@ func findBuildResults(dst []*zbstorerpc.BuildResult, conn *sqlite.Conn, logDir s
 
 				curr = &zbstorerpc.BuildResult{
 					DrvPath: drvPath,
-					DrvHash: zbstore.NonNull(drvHash),
+					DrvHash: zbstorerpc.NonNull(drvHash),
 					Status:  zbstorerpc.BuildStatus(stmt.GetText("status")),
 					Outputs: []*zbstorerpc.RealizeOutput{},
 				}

--- a/internal/backend/realize.go
+++ b/internal/backend/realize.go
@@ -933,7 +933,7 @@ func (b *builder) do(ctx context.Context, drvPath zbstore.Path, outputNames sets
 				for eqClass := range eqClasses.All() {
 					r.ReferenceClasses = append(r.ReferenceClasses, &zbstore.ReferenceClass{
 						Path:        ref,
-						Realization: zbstore.NonNull(eqClass.toRealizationOutputReference()),
+						Realization: eqClass.toRealizationOutputReference(),
 					})
 				}
 			}

--- a/internal/backend/realize_test.go
+++ b/internal/backend/realize_test.go
@@ -20,12 +20,14 @@ import (
 	"testing/synctest"
 	"time"
 
+	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/tools/txtar"
 	. "zb.256lights.llc/pkg/internal/backend"
 	"zb.256lights.llc/pkg/internal/backendtest"
 	"zb.256lights.llc/pkg/internal/fileurl"
+	"zb.256lights.llc/pkg/internal/hal"
 	"zb.256lights.llc/pkg/internal/jsonrpc"
 	"zb.256lights.llc/pkg/internal/storetest"
 	"zb.256lights.llc/pkg/internal/system"
@@ -564,48 +566,64 @@ func TestRealizeInputReference(t *testing.T) {
 	ctx := testcontext.New(t)
 	dir := backendtest.NewStoreDirectory(t)
 
-	const inputContent = "Hello, World!\n"
-	exportBuffer := new(bytes.Buffer)
-	exporter := zbstore.NewExportWriter(exportBuffer)
-	inputFilePath, _, err := storetest.ExportSourceFile(exporter, []byte(inputContent), storetest.SourceExportOptions{
-		Name:      "hello.txt",
-		Directory: dir,
-	})
+	exportArchive, err := txtar.ParseFile(filepath.Join("testdata", "TestRealizeInputReference.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects, err := storetest.TxtarObjects(dir, exportArchive.Files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputObject, err := findObjectWithName("hello.txt", slices.Values(objects))
+	if err != nil {
+		t.Fatal(err)
+	}
+	drvObject, err := findObjectWithName(derivationNameForCurrentSystem("hello-path.txt"), slices.Values(objects))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	const wantOutputName = "hello-path.txt"
-	drvContent := &zbstore.Derivation{
-		Name:   wantOutputName,
-		Dir:    dir,
-		System: system.Current().String(),
-		Env: map[string]string{
-			"in":  string(inputFilePath),
-			"out": zbstore.HashPlaceholder("out"),
-		},
-		InputSources: *sets.NewSorted(inputFilePath),
-		Outputs: map[string]*zbstore.DerivationOutputType{
-			zbstore.DefaultDerivationOutputName: zbstore.RecursiveFileFloatingCAOutput(nix.SHA256),
-		},
-	}
-	if runtime.GOOS == "windows" {
-		drvContent.Builder = powershellPath
-		drvContent.Args = []string{"-Command", "\"${env:in}`n\" | Out-File -NoNewline -Encoding ascii -FilePath ${env:out}"}
-	} else {
-		drvContent.Builder = shPath
-		drvContent.Args = []string{"-c", `echo "$in" > "$out"`}
-	}
-	drvPath, _, err := storetest.ExportDerivation(exporter, drvContent)
-	if err != nil {
-		t.Fatal(err)
+	exportBuffer := new(bytes.Buffer)
+	exporter := zbstore.NewExportWriter(exportBuffer)
+	for _, obj := range objects {
+		if err := exporter.WriteObject(ctx, obj); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := exporter.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	_, client, err := backendtest.NewServer(ctx, t, dir, &backendtest.Options{
+	uploadDir, err := filepath.Abs(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	discoveryDocument := hal.Resource{
+		Links: map[string]hal.ArrayOrObject[*hal.Link]{
+			"https://zb-build.dev/api/rel/realization": hal.Array([]*hal.Link{
+				{HRef: "realizations/{hashDigest}.json", Templated: true},
+			}),
+		},
+	}
+	discoveryJSON, err := jsonv2.Marshal(discoveryDocument)
+	if err != nil {
+		t.Fatal(err)
+	}
+	discoveryPath := filepath.Join(uploadDir, "discovery.json")
+	if err := os.WriteFile(discoveryPath, discoveryJSON, 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	server, client, err := backendtest.NewServer(ctx, t, dir, &backendtest.Options{
 		TempDir: t.TempDir(),
+		Options: Options{
+			Upload: &zbstorehttp.Store{
+				URL: fileurl.FromPath(discoveryPath),
+				HTTPClient: &http.Client{
+					Transport: fileurl.Transport{},
+				},
+			},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -622,7 +640,7 @@ func TestRealizeInputReference(t *testing.T) {
 
 	realizeResponse := new(zbstorerpc.RealizeResponse)
 	err = jsonrpc.Do(ctx, client, zbstorerpc.RealizeMethod, realizeResponse, &zbstorerpc.RealizeRequest{
-		DrvPaths: []zbstore.Path{drvPath},
+		DrvPaths: []zbstore.Path{drvObject.StorePath},
 	})
 	if err != nil {
 		t.Fatal("RPC error:", err)
@@ -635,14 +653,58 @@ func TestRealizeInputReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantOutputContent := inputFilePath + "\n"
+	wantOutputContent := string(inputObject.StorePath) + "\n"
+	wantOutputName, _ := drvObject.StorePath.DerivationName()
 	wantOutputPath, err := singleFileOutputPath(dir, wantOutputName, []byte(wantOutputContent), zbstore.References{
-		Others: *sets.NewSorted(inputFilePath),
+		Others: *sets.NewSorted(inputObject.StorePath),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkSingleFileOutput(t, drvPath, wantOutputPath, []byte(wantOutputContent), got)
+	checkSingleFileOutput(t, drvObject.StorePath, wantOutputPath, []byte(wantOutputContent), got)
+
+	// Wait until server has finished uploading.
+	if err := server.Drain(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the realizations document that is uploaded is valid.
+	if drv, err := drvObject.ParseDerivation(); err != nil {
+		t.Error(err)
+	} else {
+		drvHash, err := drv.SHA256RealizationHash(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		realizationsFilename := drvHash.RawBase32() + ".json"
+		realizationsPath := filepath.Join(uploadDir, "realizations", realizationsFilename)
+		if realizationsJSON, err := os.ReadFile(realizationsPath); err != nil {
+			t.Error(err)
+		} else {
+			var got zbstore.RealizationMap
+			want := zbstore.RealizationMap{
+				DerivationHash: drvHash,
+				Realizations: map[string][]*zbstore.Realization{
+					zbstore.DefaultDerivationOutputName: {{
+						OutputPath: wantOutputPath,
+						ReferenceClasses: []*zbstore.ReferenceClass{
+							{Path: inputObject.StorePath},
+						},
+					}},
+				},
+			}
+			err := jsonv2.Unmarshal(
+				realizationsJSON, &got,
+				jsonv2.RejectUnknownMembers(true),
+				jsonv2.WithUnmarshalers(jsonv2.UnmarshalFromFunc(zbstore.UnmarshalHashJSONFrom)),
+			)
+			if err != nil {
+				t.Error(err)
+			} else if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("%s (-want +got):\n%s", realizationsFilename, diff)
+			}
+		}
+	}
 }
 
 func TestRealizeSelfReference(t *testing.T) {

--- a/internal/backend/testdata/TestRealizeInputReference.txt
+++ b/internal/backend/testdata/TestRealizeInputReference.txt
@@ -1,0 +1,69 @@
+-- fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt --
+Hello, World!
+-- g02shnii7wnd4bq23v9ah92px0gl8w4f-hello-path-x86_64-linux.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [
+    "/opt/zb/store/fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt"
+  ],
+  "x86_64-linux",
+  "/bin/sh",
+  [
+    "-c",
+    "echo \"$in\" > \"$out\""
+  ],
+  [
+    ("in", "/opt/zb/store/fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- wfc9gg6xnyqncxg8c3kdc0lvn9viymgj-hello-path-aarch64-linux.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [
+    "/opt/zb/store/fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt"
+  ],
+  "aarch64-linux",
+  "/bin/sh",
+  [
+    "-c",
+    "echo \"$in\" > \"$out\""
+  ],
+  [
+    ("in", "/opt/zb/store/fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- nbdbgk8sbpla4w7q9ad50g82al7lyybk-hello-path-aarch64-apple-macos.txt.drv --
+Derive(
+  [("out", "", "r:sha256", "")],
+  [],
+  ["/opt/zb/store/fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt"],
+  "aarch64-apple-macos",
+  "/bin/sh",
+  ["-c","echo \"$in\" > \"$out\""],
+  [
+    ("in", "/opt/zb/store/fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)
+-- ns9s9klhb0db6h99c8myc095k1hmi971-hello-path-x86_64-pc-windows.txt.drv --
+Derive(
+  [("out","","r:sha256","")],
+  [],
+  [
+    "C:\\zb\\store\\fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt"
+  ],
+  "x86_64-pc-windows",
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  [
+    "-Command",
+    "\"${env:in}`n\" | Out-File -NoNewline -Encoding ascii -FilePath ${env:out}"
+  ],
+  [
+    ("in", "C:\\zb\\store\\fzlh7i6bd96nkzarhmvnrvmm64gsivd2-hello.txt"),
+    ("out", "/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9")
+  ]
+)

--- a/internal/storetest/fakestore.go
+++ b/internal/storetest/fakestore.go
@@ -14,6 +14,7 @@ import (
 	"zb.256lights.llc/pkg/sets"
 	"zb.256lights.llc/pkg/zbstore"
 	"zombiezen.com/go/nix"
+	"zombiezen.com/go/nix/nar"
 )
 
 var _ interface {
@@ -131,6 +132,32 @@ func (obj *Object) WriteNAR(ctx context.Context, dst io.Writer) error {
 // Trailer returns &obj.ExportTrailer.
 func (obj *Object) Trailer() *zbstore.ExportTrailer {
 	return &obj.ExportTrailer
+}
+
+// ParseDerivation parses a ".drv" object as a [*zbstore.Derivation].
+func (obj *Object) ParseDerivation() (*zbstore.Derivation, error) {
+	drvName, ok := obj.StorePath.DerivationName()
+	if !ok {
+		return nil, fmt.Errorf("parse derivation: %s is not a %s file", obj.StorePath, zbstore.DerivationExt)
+	}
+	nr := nar.NewReader(bytes.NewReader(obj.NAR))
+	hdr, err := nr.Next()
+	if err != nil {
+		return nil, err
+	}
+	if !hdr.Mode.IsRegular() {
+		return nil, fmt.Errorf("parse %s derivation: not a flat file", drvName)
+	}
+	drvData, err := io.ReadAll(nr)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s derivation: %v", drvName, err)
+	}
+	if _, err := nr.Next(); err == nil {
+		return nil, fmt.Errorf("parse %s derivation: more than a single file (bug in NAR reader?)", drvName)
+	} else if err != io.EOF {
+		return nil, fmt.Errorf("parse %s derivation: %v", drvName, err)
+	}
+	return zbstore.ParseDerivation(obj.StorePath.Dir(), drvName, drvData)
 }
 
 type storeReceiver struct {

--- a/internal/zbstorerpc/nullable.go
+++ b/internal/zbstorerpc/nullable.go
@@ -1,7 +1,7 @@
 // Copyright 2025 The zb Authors
 // SPDX-License-Identifier: MIT
 
-package zbstore
+package zbstorerpc
 
 import (
 	"fmt"

--- a/internal/zbstorerpc/zbstorerpc.go
+++ b/internal/zbstorerpc/zbstorerpc.go
@@ -409,12 +409,3 @@ type ExportRequest struct {
 	// Otherwise, paths that are referenced by those store objects will also be included.
 	ExcludeReferences bool `json:"excludeReferences"`
 }
-
-// Nullable wraps a type to permit a null JSON serialization.
-// The zero value is null.
-type Nullable[T any] = zbstore.Nullable[T]
-
-// NonNull returns a [Nullable] that wraps the given value.
-func NonNull[T any](x T) Nullable[T] {
-	return zbstore.NonNull(x)
-}

--- a/zbstore/realization_output_reference.go
+++ b/zbstore/realization_output_reference.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package zbstore
+
+import (
+	"fmt"
+
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+	jsonv1 "github.com/go-json-experiment/json/v1"
+	"zombiezen.com/go/nix"
+)
+
+// RealizationOutputReference is a reference to an output of an equivalence class of derivations.
+// It is similar to an [OutputReference], but can refers to many derivations.
+type RealizationOutputReference struct {
+	DerivationHash nix.Hash
+	OutputName     string
+}
+
+// IsZero reports whether ref is the zero value.
+func (ref RealizationOutputReference) IsZero() bool {
+	return ref.DerivationHash.IsZero() && ref.OutputName == ""
+}
+
+// String returns the hash and the output name separated by "!".
+// If ref is the zero value, then String returns "ε".
+func (ref RealizationOutputReference) String() string {
+	if ref.IsZero() {
+		return "ε"
+	}
+	return ref.DerivationHash.Base64() + "!" + ref.OutputName
+}
+
+// MarshalJSON encodes the output reference to JSON.
+// If ref.IsZero() reports true, then MarshalJSON returns "null".
+func (ref RealizationOutputReference) MarshalJSON() ([]byte, error) {
+	return jsonv2.Marshal(ref, jsonv1.DefaultOptionsV1())
+}
+
+// MarshalJSONTo encodes the output reference to a [*jsontext.Encoder].
+// If ref.IsZero() reports true, then MarshalJSONTo writes a null token.
+func (ref RealizationOutputReference) MarshalJSONTo(enc *jsontext.Encoder) error {
+	if ref.IsZero() {
+		return enc.WriteToken(jsontext.Null)
+	}
+	if ref.DerivationHash.IsZero() {
+		return fmt.Errorf("marshal realization output reference: hash not set")
+	}
+	if !IsValidOutputName(ref.OutputName) {
+		return fmt.Errorf("marshal realization output reference: invalid output name %+q", ref.OutputName)
+	}
+	if err := enc.WriteToken(jsontext.BeginObject); err != nil {
+		return fmt.Errorf("marshal realization output reference: %w", err)
+	}
+	if err := enc.WriteToken(jsontext.String("derivationHash")); err != nil {
+		return fmt.Errorf("marshal realization output reference: %w", err)
+	}
+	if err := MarshalHashJSONTo(enc, ref.DerivationHash); err != nil {
+		return fmt.Errorf("marshal realization output reference: %w", err)
+	}
+	if err := enc.WriteToken(jsontext.String("outputName")); err != nil {
+		return fmt.Errorf("marshal realization output reference: %w", err)
+	}
+	if err := enc.WriteToken(jsontext.String(ref.OutputName)); err != nil {
+		return fmt.Errorf("marshal realization output reference: %w", err)
+	}
+	if err := enc.WriteToken(jsontext.EndObject); err != nil {
+		return fmt.Errorf("marshal realization output reference: %w", err)
+	}
+	return nil
+}
+
+// UnmarshalJSON decodes an output reference from a JSON byte slice.
+// If the byte slice holds "null", then ref is set to the zero [RealizationOutputReference].
+func (ref *RealizationOutputReference) UnmarshalJSON(data []byte) error {
+	return jsonv2.Unmarshal(data, ref, jsonv1.DefaultOptionsV1())
+}
+
+// UnmarshalJSONFrom decodes an output reference from a [*jsontext.Decoder].
+// If the next token is null, then ref is set to the zero [RealizationOutputReference].
+func (ref *RealizationOutputReference) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	switch kind := dec.PeekKind(); kind {
+	case 'n':
+		if _, err := dec.ReadToken(); err != nil {
+			return fmt.Errorf("unmarshal realization output reference: %w", err)
+		}
+		*ref = RealizationOutputReference{}
+		return nil
+	case '{':
+		var parsed struct {
+			DerivationHash nix.Hash `json:"derivationHash"`
+			OutputName     string   `json:"outputName"`
+		}
+		unmarshalersOption := jsonv2.WithUnmarshalers(jsonv2.UnmarshalFromFunc(UnmarshalHashJSONFrom))
+		if err := jsonv2.UnmarshalDecode(dec, &parsed, unmarshalersOption); err != nil {
+			return fmt.Errorf("unmarshal realization output reference: %w", err)
+		}
+		if parsed.DerivationHash.IsZero() {
+			return fmt.Errorf("unmarshal realization output reference: hash not set")
+		}
+		if !IsValidOutputName(parsed.OutputName) {
+			return fmt.Errorf("unmarshal realization output reference: invalid output name %+q", parsed.OutputName)
+		}
+		*ref = RealizationOutputReference(parsed)
+		return nil
+	default:
+		return fmt.Errorf("unmarshal realization output reference: must be object or null (got %v)", kind)
+	}
+}

--- a/zbstore/realization_output_reference_test.go
+++ b/zbstore/realization_output_reference_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package zbstore
+
+import (
+	"testing"
+
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type realizationOutputReferenceJSONTest struct {
+	json                       map[string]any
+	realizationOutputReference RealizationOutputReference
+	err                        bool
+}
+
+func realizationOutputReferenceJSONTests(tb testing.TB) []realizationOutputReferenceJSONTest {
+	return []realizationOutputReferenceJSONTest{
+		{
+			realizationOutputReference: RealizationOutputReference{},
+			json:                       nil,
+		},
+		{
+			realizationOutputReference: RealizationOutputReference{
+				DerivationHash: mustParseHash(tb, "sha256-E7vF8sqxzZakF3PIARooaSxc9nHFK03NE+tZ7JTtIvQ="),
+				OutputName:     "out",
+			},
+			json: map[string]any{
+				"derivationHash": map[string]any{
+					"algorithm": "sha256",
+					"digest":    "E7vF8sqxzZakF3PIARooaSxc9nHFK03NE+tZ7JTtIvQ=",
+				},
+				"outputName": "out",
+			},
+		},
+		{
+			json: map[string]any{},
+			err:  true,
+		},
+		{
+			json: map[string]any{
+				"outputName": "out",
+			},
+			err: true,
+		},
+		{
+			json: map[string]any{
+				"derivationHash": map[string]any{
+					"algorithm": "sha256",
+					"digest":    "E7vF8sqxzZakF3PIARooaSxc9nHFK03NE+tZ7JTtIvQ=",
+				},
+			},
+			err: true,
+		},
+	}
+}
+
+func (test realizationOutputReferenceJSONTest) inputJSON(tb testing.TB) []byte {
+	tb.Helper()
+	if test.json == nil {
+		return []byte("null")
+	}
+	gotJSON, err := jsonv2.Marshal(test.json)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return gotJSON
+}
+
+func TestRealizationOutputReferenceMarshalJSON(t *testing.T) {
+	for _, test := range realizationOutputReferenceJSONTests(t) {
+		if test.err {
+			continue
+		}
+		gotJSON, err := jsonv2.Marshal(test.realizationOutputReference)
+		if err != nil {
+			t.Errorf("%v: %v", test.realizationOutputReference, err)
+			continue
+		}
+		var got map[string]any
+		if err := jsonv2.Unmarshal(gotJSON, &got); err != nil {
+			t.Errorf("%v: %v", test.realizationOutputReference, err)
+			continue
+		}
+		if diff := cmp.Diff(test.json, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("marshal %v (-want +got):\n%s", test.realizationOutputReference, diff)
+		}
+	}
+}
+
+func TestRealizationOutputReferenceUnmarshalJSON(t *testing.T) {
+	for _, test := range realizationOutputReferenceJSONTests(t) {
+		inputJSON := test.inputJSON(t)
+		var got RealizationOutputReference
+		err := jsonv2.Unmarshal(inputJSON, &got, jsonv2.RejectUnknownMembers(true))
+		if err != nil && !test.err {
+			t.Errorf("%v: %v", test.realizationOutputReference, err)
+			continue
+		} else if test.err {
+			if err == nil {
+				t.Errorf("%s did not produce an error", inputJSON)
+			} else {
+				t.Logf("%s error (as expected): %v", inputJSON, err)
+			}
+			continue
+		}
+		if diff := cmp.Diff(test.realizationOutputReference, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("unmarshal %v (-want +got):\n%s", test.realizationOutputReference, diff)
+		}
+	}
+}
+
+func FuzzRealizationOutputReferenceJSON(f *testing.F) {
+	for _, test := range realizationOutputReferenceJSONTests(f) {
+		f.Add(test.inputJSON(f))
+	}
+
+	unmarshalOptions := jsonv2.JoinOptions(
+		jsonv2.RejectUnknownMembers(true),
+	)
+	f.Fuzz(func(t *testing.T, inputJSON []byte) {
+		var got1 RealizationOutputReference
+		if err := jsonv2.Unmarshal(inputJSON, &got1, unmarshalOptions); err != nil {
+			t.Skip(err)
+		}
+		gotJSON, err := jsonv2.Marshal(got1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got2 RealizationOutputReference
+		err = jsonv2.Unmarshal(gotJSON, &got2, unmarshalOptions)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(got1, got2, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("after remarshaling (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/zbstore/zbstore.go
+++ b/zbstore/zbstore.go
@@ -462,8 +462,8 @@ func realizationKeysEqual(r1, r2 *Realization) bool {
 
 // A ReferenceClass is a mapping of referenced path to optional realization.
 type ReferenceClass struct {
-	Path        Path                                 `json:"path"`
-	Realization Nullable[RealizationOutputReference] `json:"realization"`
+	Path        Path                       `json:"path"`
+	Realization RealizationOutputReference `json:"realization"`
 }
 
 func compareReferenceClasses(rc1, rc2 *ReferenceClass) int {
@@ -471,15 +471,15 @@ func compareReferenceClasses(rc1, rc2 *ReferenceClass) int {
 		return result
 	}
 	switch {
-	case !rc1.Realization.Valid && !rc2.Realization.Valid:
+	case rc1.Realization.IsZero() && rc2.Realization.IsZero():
 		return 0
-	case !rc1.Realization.Valid && rc2.Realization.Valid:
+	case rc1.Realization.IsZero() && !rc2.Realization.IsZero():
 		return -1
-	case rc1.Realization.Valid && !rc2.Realization.Valid:
+	case !rc1.Realization.IsZero() && rc2.Realization.IsZero():
 		return 1
 	}
-	ref1 := rc1.Realization.X
-	ref2 := rc2.Realization.X
+	ref1 := rc1.Realization
+	ref2 := rc2.Realization
 	if result := cmp.Compare(ref1.DerivationHash.Type(), ref2.DerivationHash.Type()); result != 0 {
 		return result
 	}
@@ -487,23 +487,6 @@ func compareReferenceClasses(rc1, rc2 *ReferenceClass) int {
 		bytes.Compare(ref1.DerivationHash.Bytes(nil), ref2.DerivationHash.Bytes(nil)),
 		cmp.Compare(ref1.OutputName, ref2.OutputName),
 	)
-}
-
-// RealizationOutputReference is a reference to an output of an equivalence class of derivations.
-// It is similar to an [OutputReference], but can refers to many derivations.
-type RealizationOutputReference struct {
-	DerivationHash nix.Hash `json:"derivationHash"`
-	OutputName     string   `json:"outputName"`
-}
-
-// IsZero reports whether ref is the zero value.
-func (ref RealizationOutputReference) IsZero() bool {
-	return ref.DerivationHash.IsZero() && ref.OutputName == ""
-}
-
-// String returns the hash and the output name separated by "!".
-func (ref RealizationOutputReference) String() string {
-	return ref.DerivationHash.Base64() + "!" + ref.OutputName
 }
 
 // RealizationSignatureFormat is an enumeration of formats for [RealizationSignature].
@@ -673,6 +656,9 @@ func marshalRealizationForSignature(ref RealizationOutputReference, r *Realizati
 //
 // [realization format]: https://zb.256lights.llc/binary-cache/realizations
 func MarshalHashJSONTo(enc *jsontext.Encoder, hash nix.Hash) error {
+	if hash.IsZero() {
+		return fmt.Errorf("marshal hash: zero hash")
+	}
 	if err := enc.WriteToken(jsontext.BeginObject); err != nil {
 		return fmt.Errorf("marshal hash: %v", err)
 	}
@@ -722,33 +708,26 @@ func compareReferenceClassesForSignature(rc1, rc2 *ReferenceClass) int {
 	if result := cmp.Compare(rc1.Path, rc2.Path); result != 0 {
 		return result
 	}
-	if rc1.Realization.Valid != rc2.Realization.Valid {
-		if rc1.Realization.Valid {
-			return 1
-		} else {
-			return -1
-		}
-	}
 	switch {
-	case !rc1.Realization.Valid && !rc2.Realization.Valid:
+	case rc1.Realization.IsZero() && rc2.Realization.IsZero():
 		return 0
-	case !rc1.Realization.Valid && rc2.Realization.Valid:
+	case rc1.Realization.IsZero() && !rc2.Realization.IsZero():
 		return -1
-	case rc1.Realization.Valid && !rc2.Realization.Valid:
+	case !rc1.Realization.IsZero() && rc2.Realization.IsZero():
 		return 1
 	}
 	return cmp.Or(
 		cmp.Compare(
-			rc1.Realization.X.DerivationHash.Type().String(),
-			rc2.Realization.X.DerivationHash.Type().String(),
+			rc1.Realization.DerivationHash.Type().String(),
+			rc2.Realization.DerivationHash.Type().String(),
 		),
 		cmp.Compare(
-			rc1.Realization.X.DerivationHash.RawBase64(),
-			rc2.Realization.X.DerivationHash.RawBase64(),
+			rc1.Realization.DerivationHash.RawBase64(),
+			rc2.Realization.DerivationHash.RawBase64(),
 		),
 		cmp.Compare(
-			rc1.Realization.X.OutputName,
-			rc2.Realization.X.OutputName,
+			rc1.Realization.OutputName,
+			rc2.Realization.OutputName,
 		),
 	)
 }

--- a/zbstore/zbstore_test.go
+++ b/zbstore/zbstore_test.go
@@ -241,12 +241,9 @@ func TestRealizationMapClone(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -268,12 +265,9 @@ func TestRealizationMapClone(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -344,12 +338,9 @@ func TestRealizationMapCompact(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -371,12 +362,9 @@ func TestRealizationMapCompact(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -402,12 +390,9 @@ func TestRealizationMapCompact(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -446,12 +431,9 @@ func TestRealizationMapCompact(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -473,12 +455,9 @@ func TestRealizationMapCompact(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -504,12 +483,9 @@ func TestRealizationMapCompact(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -593,12 +569,9 @@ func TestRealizationMapMerge(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -628,12 +601,9 @@ func TestRealizationMapMerge(t *testing.T) {
 								ReferenceClasses: []*ReferenceClass{
 									{
 										Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-										Realization: Nullable[RealizationOutputReference]{
-											Valid: true,
-											X: RealizationOutputReference{
-												DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-												OutputName:     "foo",
-											},
+										Realization: RealizationOutputReference{
+											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+											OutputName:     "foo",
 										},
 									},
 								},
@@ -660,12 +630,9 @@ func TestRealizationMapMerge(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -704,12 +671,9 @@ func TestRealizationMapMerge(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -739,12 +703,9 @@ func TestRealizationMapMerge(t *testing.T) {
 								ReferenceClasses: []*ReferenceClass{
 									{
 										Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-										Realization: Nullable[RealizationOutputReference]{
-											Valid: true,
-											X: RealizationOutputReference{
-												DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-												OutputName:     "foo",
-											},
+										Realization: RealizationOutputReference{
+											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+											OutputName:     "foo",
 										},
 									},
 								},
@@ -771,12 +732,9 @@ func TestRealizationMapMerge(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},
@@ -819,12 +777,9 @@ func TestRealizationMapMerge(t *testing.T) {
 								ReferenceClasses: []*ReferenceClass{
 									{
 										Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-										Realization: Nullable[RealizationOutputReference]{
-											Valid: true,
-											X: RealizationOutputReference{
-												DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-												OutputName:     "foo",
-											},
+										Realization: RealizationOutputReference{
+											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+											OutputName:     "foo",
 										},
 									},
 								},
@@ -843,12 +798,9 @@ func TestRealizationMapMerge(t *testing.T) {
 								ReferenceClasses: []*ReferenceClass{
 									{
 										Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-										Realization: Nullable[RealizationOutputReference]{
-											Valid: true,
-											X: RealizationOutputReference{
-												DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-												OutputName:     "foo",
-											},
+										Realization: RealizationOutputReference{
+											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+											OutputName:     "foo",
 										},
 									},
 								},
@@ -878,12 +830,9 @@ func TestRealizationMapMerge(t *testing.T) {
 							ReferenceClasses: []*ReferenceClass{
 								{
 									Path: "/opt/zb/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bar",
-									Realization: Nullable[RealizationOutputReference]{
-										Valid: true,
-										X: RealizationOutputReference{
-											DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
-											OutputName:     "foo",
-										},
+									Realization: RealizationOutputReference{
+										DerivationHash: mustParseHash(t, "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA="),
+										OutputName:     "foo",
 									},
 								},
 							},


### PR DESCRIPTION
- Rework `RealizationOutputReference` to marshal the zero value to `null` in JSON. Add unit tests to verify.
- Move `zbstore.Nullable` into `internal/zbstorerpc`, since that was the only usage in `zbstore`.
- Add check in `TestRealizeInputReference` for realizations in upload store.
- Convert `TestRealizeInputReference` input to txtar.
- Use "ε" as string representation for zero `RealizationOutputReference`.