### PR TITLE
Fix HTTP cache for responses that are >16KiB

### DIFF
--- a/internal/httpcache/buffer.go
+++ b/internal/httpcache/buffer.go
@@ -1,0 +1,252 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package httpcache
+
+import (
+	"fmt"
+	"io"
+
+	"zb.256lights.llc/pkg/internal/multierror"
+	"zombiezen.com/go/sqlite"
+	"zombiezen.com/go/sqlite/sqlitex"
+)
+
+// bufferPageSize is the increment in which to page out potentially large responses to disk
+// as they are being streamed from the origin server.
+const bufferPageSize = 16 << 10 // 16 KiB
+
+// A buffer is a variable-sized byte buffer
+// backed by a fixed in-memory buffer (size 2 * [bufferPageSize])
+// and a SQLite connection's [temporary database].
+// Methods on a buffer can be called inside or outside of a transaction.
+//
+// [temporary database]: https://sqlite.org/tempfiles.html#temp_databases
+type buffer struct {
+	conn *sqlite.Conn
+
+	rbuf    []byte
+	rpos    int
+	n       int64
+	blobIDs []int64
+
+	wbuf []byte
+	werr error
+}
+
+// newBuffer returns a new [*buffer]
+// that is backed by the given SQLite connection.
+// The caller is responsible for calling [*buffer.Close]
+// when it is no longer using the buffer.
+func newBuffer(conn *sqlite.Conn) (*buffer, error) {
+	stmt := conn.Prep(`create table if not exists temp."httpCacheBuffer" ("blob" blob not null);`)
+	if err := runStatement(stmt); err != nil {
+		return nil, fmt.Errorf("create buffer: %v", err)
+	}
+	buf := make([]byte, 2*bufferPageSize)
+	return &buffer{
+		conn: conn,
+		rbuf: buf[:0:bufferPageSize],
+		wbuf: buf[bufferPageSize:bufferPageSize],
+	}, nil
+}
+
+// Len returns the number of unread bytes in the buffer.
+func (buf *buffer) Len() int64 {
+	return buf.n
+}
+
+// Write writes p to the end of the buffer.
+func (buf *buffer) Write(p []byte) (n int, err error) {
+	for len(p) > 0 {
+		buf.flushIfFull()
+		if buf.werr != nil {
+			return n, buf.werr
+		}
+		nn := copy(buf.wbuf[len(buf.wbuf):cap(buf.wbuf)], p)
+		buf.wbuf = buf.wbuf[:len(buf.wbuf)+nn]
+		n += nn
+		buf.n += int64(nn)
+		p = p[nn:]
+	}
+	return n, nil
+}
+
+// WriteByte writes b to the end of the buffer.
+func (buf *buffer) WriteByte(b byte) error {
+	buf.flushIfFull()
+	if buf.werr != nil {
+		return buf.werr
+	}
+	buf.wbuf = append(buf.wbuf, b)
+	buf.n++
+	return nil
+}
+
+// ReadFrom reads data from r until [io.EOF] or error
+// and writes it to the end of the buffer.
+// ReadFrom returns the number of bytes read
+// and any error except [io.EOF] encountered during the read.
+func (buf *buffer) ReadFrom(r io.Reader) (n int64, err error) {
+	for {
+		buf.flushIfFull()
+		if buf.werr != nil {
+			return n, buf.werr
+		}
+		var nn int
+		nn, err = r.Read(buf.wbuf[len(buf.wbuf):cap(buf.wbuf)])
+		buf.wbuf = buf.wbuf[:len(buf.wbuf)+nn]
+		buf.n += int64(nn)
+		n += int64(nn)
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return n, err
+		}
+	}
+}
+
+// flushIfFull copies buf.wbuf to a new blob in the temp table
+// if it is at capacity.
+// If any error occurs, it is stored in buf.werr.
+func (buf *buffer) flushIfFull() {
+	if len(buf.wbuf) < cap(buf.wbuf) || buf.werr != nil {
+		return
+	}
+
+	stmt := buf.conn.Prep(`insert into temp."httpCacheBuffer" values (?);`)
+	stmt.BindBytes(1, buf.wbuf)
+	if err := runStatement(stmt); err != nil {
+		buf.werr = fmt.Errorf("write cache buffer: %v", err)
+		return
+	}
+	buf.blobIDs = append(buf.blobIDs, buf.conn.LastInsertRowID())
+	buf.wbuf = buf.wbuf[:0]
+}
+
+// Read reads up to len(p) bytes from the beginning of the buffer into p.
+func (buf *buffer) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if err := buf.fillReadBuffer(); err != nil {
+		return 0, fmt.Errorf("read cache buffer: %v", err)
+	}
+	n = copy(p, buf.rbuf[buf.rpos:])
+	buf.rpos += n
+	buf.n -= int64(n)
+	if buf.rpos >= len(buf.rbuf) && len(buf.blobIDs) == 0 && len(buf.wbuf) == 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// ReadByte reads and returns the next byte from the input or any error encountered.
+func (buf *buffer) ReadByte() (byte, error) {
+	if err := buf.fillReadBuffer(); err != nil {
+		return 0, fmt.Errorf("read cache buffer: %v", err)
+	}
+	if buf.rpos >= len(buf.rbuf) {
+		return 0, io.EOF
+	}
+	b := buf.rbuf[buf.rpos]
+	buf.rpos++
+	buf.n--
+	return b, nil
+}
+
+// WriteTo writes the buffer to w,
+// returning the number of bytes written and any error encountered.
+func (buf *buffer) WriteTo(w io.Writer) (n int64, err error) {
+	for {
+		if err := buf.fillReadBuffer(); err != nil {
+			return n, fmt.Errorf("read cache buffer: %v", err)
+		}
+		if buf.rpos >= len(buf.rbuf) {
+			return n, nil
+		}
+		var nn int
+		nn, err = w.Write(buf.rbuf[buf.rpos:])
+		buf.n -= int64(nn)
+		n += int64(nn)
+		buf.rpos += nn
+		if err != nil {
+			return n, err
+		}
+	}
+}
+
+// fillReadBuffer moves the next (potentially in-progress) blob into buf.rbuf
+// if there are no more bytes to read from buf.rbuf.
+func (buf *buffer) fillReadBuffer() (err error) {
+	if buf.rpos < len(buf.rbuf) {
+		return nil
+	}
+	if len(buf.blobIDs) == 0 {
+		n := copy(buf.rbuf[:cap(buf.rbuf)], buf.wbuf)
+		buf.rbuf = buf.rbuf[:n]
+		buf.rpos = 0
+		buf.wbuf = append(buf.wbuf[:0], buf.wbuf[n:]...)
+		return nil
+	}
+
+	defer sqlitex.Save(buf.conn)(&err)
+	stmt := buf.conn.Prep(`select "blob" from temp."httpCacheBuffer" where rowid = ? limit 1;`)
+	id := buf.blobIDs[0]
+	stmt.BindInt64(1, id)
+	hasRow, err := stmt.Step()
+	if err != nil {
+		stmt.Reset()
+		return err
+	}
+	if !hasRow {
+		return fmt.Errorf("missing blob rowid=%d", id)
+	}
+	blobSize := stmt.ColumnLen(0)
+	if blobSize > cap(buf.rbuf) {
+		stmt.Reset()
+		return fmt.Errorf("blob rowid=%d is %d bytes (>%d-byte page size)", id, blobSize, cap(buf.rbuf))
+	}
+	buf.rbuf = buf.rbuf[:blobSize]
+	buf.rpos = 0
+	stmt.ColumnBytes(0, buf.rbuf)
+	stmt.Reset()
+	buf.popBlobs(1)
+
+	return nil
+}
+
+// Close clears the buffer and releases its resources.
+func (buf *buffer) Close() (err error) {
+	buf.rbuf = buf.rbuf[:0]
+	buf.rpos = 0
+	buf.wbuf = buf.wbuf[:0]
+	return buf.popBlobs(len(buf.blobIDs))
+}
+
+func (buf *buffer) popBlobs(n int) (err error) {
+	if len(buf.blobIDs) == 0 {
+		return nil
+	}
+	var ec multierror.Collector
+	releaseFunc := sqlitex.Save(buf.conn)
+	defer func() {
+		// Always try to commit as much as possible to save storage.
+		var releaseError error
+		releaseFunc(&releaseError)
+		if releaseError != nil {
+			ec.Add(fmt.Errorf("delete cache buffer blobs: %v", releaseError))
+		}
+		err = ec.Error()
+	}()
+	stmt := buf.conn.Prep(`delete from temp."httpCacheBuffer" where rowid = ?;`)
+	for _, id := range buf.blobIDs[:n] {
+		stmt.BindInt64(1, id)
+		if err := runStatement(stmt); err != nil {
+			ec.Add(fmt.Errorf("delete cache buffer blob rowid=%d: %v", id, err))
+		}
+	}
+	buf.blobIDs = append(buf.blobIDs[:0], buf.blobIDs[n:]...)
+	return nil
+}

--- a/internal/httpcache/buffer_test.go
+++ b/internal/httpcache/buffer_test.go
@@ -1,0 +1,376 @@
+// Copyright 2026 The zb Authors
+// SPDX-License-Identifier: MIT
+
+package httpcache
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"zombiezen.com/go/sqlite"
+)
+
+func TestBuffer(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(w io.Writer) error
+	}{
+		{
+			name: "NoWrites",
+			write: func(w io.Writer) error {
+				return nil
+			},
+		},
+		{
+			name: "EmptyWrite",
+			write: func(w io.Writer) error {
+				if n, err := w.Write(nil); err != nil {
+					return err
+				} else if n != 0 {
+					return fmt.Errorf("no error returned, but n = %d; want 0", n)
+				}
+				return nil
+			},
+		},
+		{
+			name: "SingleSmall",
+			write: func(w io.Writer) error {
+				const p = "Hello, World!\n"
+				if n, err := w.Write([]byte(p)); err != nil {
+					return err
+				} else if n != len(p) {
+					return fmt.Errorf("no error returned, but n = %d; want %d", n, len(p))
+				}
+				return nil
+			},
+		},
+		{
+			name: "ByteAtATimeLarge",
+			write: func(w io.Writer) error {
+				const wantSize = bufferPageSize*2 + 1
+
+				buf := [1]byte{'x'}
+
+				for range wantSize - 1 {
+					if n, err := w.Write(buf[:]); err != nil {
+						return err
+					} else if n != 1 {
+						return fmt.Errorf("no error returned, but n = %d; want 1", n)
+					}
+				}
+				buf[0] = '\n'
+				if n, err := w.Write(buf[:]); err != nil {
+					return err
+				} else if n != 1 {
+					return fmt.Errorf("no error returned, but n = %d; want 1", n)
+				}
+				return nil
+			},
+		},
+		{
+			name: "ByteWriterLarge",
+			write: func(w io.Writer) error {
+				const wantSize = bufferPageSize*2 + 1
+
+				bw, isByteWriter := w.(io.ByteWriter)
+				buf := [1]byte{'x'}
+				write := func() error {
+					if isByteWriter {
+						return bw.WriteByte(buf[0])
+					}
+					n, err := w.Write(buf[:])
+					if err != nil {
+						return err
+					}
+					if n != 1 {
+						return fmt.Errorf("no error returned, but n = %d; want 1", n)
+					}
+					return nil
+				}
+
+				for range wantSize - 1 {
+					if err := write(); err != nil {
+						return err
+					}
+				}
+				buf[0] = '\n'
+				if err := write(); err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+		{
+			name: "OneLargeWrite",
+			write: func(w io.Writer) error {
+				const wantSize = bufferPageSize*2 + 1
+				buf := make([]byte, 0, wantSize)
+				for range wantSize - 1 {
+					buf = append(buf, 'x')
+				}
+				buf = append(buf, '\n')
+
+				if n, err := w.Write(buf); err != nil {
+					return err
+				} else if n != len(buf) {
+					return fmt.Errorf("no error returned, but n = %d; want %d", n, len(buf))
+				}
+				return nil
+			},
+		},
+		{
+			name: "ReadFromLarge",
+			write: func(w io.Writer) error {
+				type onlyReader struct {
+					io.Reader
+				}
+
+				const wantSize = bufferPageSize*2 + 1
+				buf := make([]byte, 0, wantSize)
+				for range wantSize - 1 {
+					buf = append(buf, 'x')
+				}
+				buf = append(buf, '\n')
+
+				n, err := io.Copy(w, onlyReader{bytes.NewReader(buf)})
+				if err != nil {
+					return err
+				} else if n != int64(len(buf)) {
+					return fmt.Errorf("no error returned, but n = %d; want %d", n, len(buf))
+				}
+				return nil
+			},
+		},
+		{
+			name: "SmallWriteThenReadFromLarge",
+			write: func(w io.Writer) error {
+				type onlyReader struct {
+					io.Reader
+				}
+
+				const wantSize = bufferPageSize*2 + 1
+				buf := make([]byte, 0, wantSize)
+
+				buf = append(buf, "yyy"...)
+				n, err := w.Write(buf)
+				if err != nil {
+					return err
+				} else if n != len(buf) {
+					return fmt.Errorf("no error returned, but n = %d; want %d", n, len(buf))
+				}
+
+				buf = buf[:0]
+				for range wantSize - 1 {
+					buf = append(buf, 'x')
+				}
+				buf = append(buf, '\n')
+
+				n64, err := io.Copy(w, onlyReader{bytes.NewReader(buf)})
+				if err != nil {
+					return err
+				} else if n64 != int64(len(buf)) {
+					return fmt.Errorf("no error returned, but n = %d; want %d", n64, len(buf))
+				}
+				return nil
+			},
+		},
+	}
+
+	readStrategies := []struct {
+		name string
+		read func(buf *buffer) ([]byte, error)
+	}{
+		{
+			name: "Read",
+			read: func(buf *buffer) ([]byte, error) {
+				return io.ReadAll(buf)
+			},
+		},
+		{
+			name: "ReadByte",
+			read: func(buf *buffer) ([]byte, error) {
+				got := new(bytes.Buffer)
+				for {
+					b, err := buf.ReadByte()
+					if err != nil {
+						if err == io.EOF {
+							err = nil
+						}
+						return got.Bytes(), err
+					}
+					got.WriteByte(b)
+				}
+			},
+		},
+		{
+			name: "WriterTo",
+			read: func(buf *buffer) ([]byte, error) {
+				got := new(bytes.Buffer)
+				n, err := io.Copy(got, buf)
+				if err == nil && n != int64(got.Len()) {
+					err = fmt.Errorf("io.Copy(...) = %d, <nil>; want %d, <nil>", n, got.Len())
+				}
+				return got.Bytes(), err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			want := new(bytes.Buffer)
+			if err := test.write(want); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, strategy := range readStrategies {
+				t.Run(strategy.name, func(t *testing.T) {
+					conn, err := sqlite.OpenConn(":memory:", sqlite.OpenReadWrite)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer func() {
+						if err := conn.Close(); err != nil {
+							t.Error("conn.Close:", err)
+						}
+					}()
+
+					buf, err := newBuffer(conn)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer func() {
+						if err := buf.Close(); err != nil {
+							t.Error("buf.Close:", err)
+						}
+					}()
+
+					if err := test.write(buf); err != nil {
+						t.Error("during write:", err)
+					}
+					if got, want := buf.Len(), int64(want.Len()); got != want {
+						t.Errorf("after write, buf.Len() = %d; want %d", got, want)
+					}
+
+					got, err := strategy.read(buf)
+					if err != nil {
+						t.Error("during read:", err)
+					}
+					if !bytes.Equal(got, want.Bytes()) {
+						gotPath := filepath.Join(t.ArtifactDir(), "got.out")
+						os.WriteFile(gotPath, got, 0o666)
+						wantPath := filepath.Join(t.ArtifactDir(), "want.out")
+						os.WriteFile(wantPath, want.Bytes(), 0o666)
+
+						t.Errorf("Buffer content does not match (%d bytes vs. %d bytes). Wrote to %s",
+							len(got), want.Len(), gotPath)
+					}
+
+					if got := buf.Len(); got != 0 {
+						t.Errorf("after write, buf.Len() = %d; want 0", got)
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkBufferRead(b *testing.B) {
+	conn, err := sqlite.OpenConn(":memory:", sqlite.OpenReadWrite)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			b.Error("conn.Close:", err)
+		}
+	}()
+
+	buf, err := newBuffer(conn)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := buf.Close(); err != nil {
+			b.Error("buf.Close:", err)
+		}
+	}()
+
+	payload := make([]byte, bufferPageSize*4)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	b.SetBytes(int64(len(payload)))
+
+	got := make([]byte, len(payload))
+
+	for b.Loop() {
+		b.StopTimer()
+		n, err := buf.Write(payload)
+		if err != nil {
+			b.Fatal("buf.Write:", err)
+		}
+		if n != len(payload) {
+			b.Fatalf("buf.Write wrote %d bytes out of %d", n, len(payload))
+		}
+		b.StartTimer()
+
+		n, err = io.ReadFull(buf, got)
+		if n < len(got) {
+			b.Errorf("read %d bytes out of %d", n, len(got))
+		}
+		if err != nil {
+			b.Error("read error:", err)
+		}
+		if b.Failed() {
+			return
+		}
+	}
+}
+
+func BenchmarkBufferWrite(b *testing.B) {
+	conn, err := sqlite.OpenConn(":memory:", sqlite.OpenReadWrite)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			b.Error("conn.Close:", err)
+		}
+	}()
+
+	buf, err := newBuffer(conn)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := buf.Close(); err != nil {
+			b.Error("buf.Close:", err)
+		}
+	}()
+
+	payload := make([]byte, bufferPageSize*4)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	b.SetBytes(int64(len(payload)))
+
+	for b.Loop() {
+		n, err := buf.Write(payload)
+		if err != nil {
+			b.Fatal("buf.Write:", err)
+		}
+		if n != len(payload) {
+			b.Fatalf("buf.Write wrote %d bytes out of %d", n, len(payload))
+		}
+
+		b.StopTimer()
+		if err := buf.Close(); err != nil {
+			b.Fatal("buf.Close:", err)
+		}
+		b.StartTimer()
+	}
+}

--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -25,7 +25,6 @@ import (
 	"zb.256lights.llc/pkg/internal/xhttp"
 	"zb.256lights.llc/pkg/internal/xtime"
 	"zombiezen.com/go/sqlite"
-	"zombiezen.com/go/sqlite/sqlitefile"
 	"zombiezen.com/go/sqlite/sqlitemigration"
 	"zombiezen.com/go/sqlite/sqlitex"
 )
@@ -355,7 +354,7 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return result.response, nil
 	}
 
-	bodyBuffer, err := sqlitefile.NewBuffer(conn)
+	bodyBuffer, err := newBuffer(conn)
 	if err != nil {
 		rt.reportError(req, deleteResource(conn, idResult.id))
 		return result.response, nil
@@ -875,11 +874,11 @@ func (hu headerUpserter) upsert(key, value string) (id int64, err error) {
 type bufferedResponseBody struct {
 	db     *sqlitemigration.Pool
 	conn   *sqlite.Conn
-	buffer *sqlitefile.Buffer
+	buffer *buffer
 	body   io.ReadCloser
 }
 
-func (rt *RoundTripper) newBufferedResponseBody(conn *sqlite.Conn, buffer *sqlitefile.Buffer, body io.ReadCloser) *bufferedResponseBody {
+func (rt *RoundTripper) newBufferedResponseBody(conn *sqlite.Conn, buffer *buffer, body io.ReadCloser) *bufferedResponseBody {
 	return &bufferedResponseBody{
 		db:     rt.db,
 		conn:   conn,

--- a/internal/httpcache/httpcache_test.go
+++ b/internal/httpcache/httpcache_test.go
@@ -252,7 +252,14 @@ func TestRoundTripperVaryAuthorization(t *testing.T) {
 
 func TestRoundTripperLargeUnsizedBody(t *testing.T) {
 	testTime := time.Now().UTC()
-	const wantBody = "Hello, User!\n"
+	const maxResponseSize = bufferPageSize*2 + 1
+	wantBodyBuilder := new(strings.Builder)
+	wantBodyBuilder.Grow(maxResponseSize + 1)
+	for range maxResponseSize {
+		wantBodyBuilder.WriteByte('x')
+	}
+	wantBodyBuilder.WriteByte('\n')
+	wantBody := wantBodyBuilder.String()
 	mockServer := &mockRoundTripper{
 		tb: t,
 		responses: []*testRequestResponse{
@@ -273,7 +280,7 @@ func TestRoundTripperLargeUnsizedBody(t *testing.T) {
 
 	dbPath := filepath.Join(t.TempDir(), "http-cache.sqlite")
 	cache := Open(dbPath, mockServer, &Options{
-		MaxResponseSize: 8,
+		MaxResponseSize: maxResponseSize,
 		ErrorReporter: ErrorReporterFunc(func(ctx context.Context, info *RequestInfo, err error) {
 			if info != nil {
 				t.Errorf("Cache error on %s %v: %v", info.Method, info.URL, err)


### PR DESCRIPTION
The `sqlitefile` package hangs onto incremental BLOB I/O handles to allow reusing the same pages and some amount of unread. Keeping BLOB handles open prevents transactions from finishing. I created my own buffer type that reads and writes BLOBs atomically and operates the way the surrounding code expects the buffer to behave.

`TestRoundTripperLargeUnsizedBody` was not exercising the code path because it was not reading a body that exceeded the buffer page size. I rewrote the test to operate on a larger body, and was able to replicate the failure seen in the issue.

Fixes #326