### PR TITLE
Rename `storetest.Object` to `zbstore.Blob`

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -95,7 +94,7 @@ func TestImport(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			} else {
-				want := wantObjectInfo(info.Info, obj.NAR, obj.ContentAddress, &obj.References)
+				want := wantObjectInfo(info.Info, obj)
 				if diff := cmp.Diff(want, info.Info); diff != "" {
 					t.Errorf("%s info (-want +got):\n%s", obj.StorePath, diff)
 				}
@@ -463,29 +462,18 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-// wantObjectInfo builds the expected [*zbstorerpc.ObjectInfo]
-// for the given data, content address, and references.
+// wantObjectInfo builds the expected [*zbstorerpcrpc.ObjectInfo] for the given blob.
 // It uses got.NARHash to determine the hashing algorithm to check against.
-func wantObjectInfo(got *zbstorerpc.ObjectInfo, narData []byte, ca zbstore.ContentAddress, refs *sets.Sorted[zbstore.Path]) *zbstorerpc.ObjectInfo {
-	info := &zbstorerpc.ObjectInfo{
-		NARSize:        int64(len(narData)),
-		References:     slices.Collect(refs.Values()),
-		ContentAddress: ca,
-	}
-	if info.References == nil {
-		// Should not be null.
-		info.References = []zbstore.Path{}
-	}
-
+func wantObjectInfo(got *zbstorerpc.ObjectInfo, blob *zbstore.Blob) *zbstorerpc.ObjectInfo {
 	ht := got.NARHash.Type()
 	if ht == 0 {
 		ht = nix.SHA256
 	}
 	h := nix.NewHasher(ht)
-	h.Write(narData)
-	info.NARHash = h.SumHash()
-
-	return info
+	h.Write(blob.NAR)
+	want := new(*blob.Info())
+	want.NARHash = h.SumHash()
+	return zbstorerpc.NewObjectInfo(want)
 }
 
 func storeCodec(ctx context.Context, client *jsonrpc.Client) (codec *zbstorerpc.Codec, release func(), err error) {

--- a/internal/backend/realize_test.go
+++ b/internal/backend/realize_test.go
@@ -553,9 +553,14 @@ func TestRealizeReferenceToDep(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		want := wantObjectInfo(info.Info, narData, ca, sets.NewSorted(
-			drv1OutputPath,
-		))
+		want := wantObjectInfo(info.Info, &zbstore.Blob{
+			NAR: narData,
+			ExportTrailer: zbstore.ExportTrailer{
+				StorePath:      wantOutputPath,
+				ContentAddress: ca,
+				References:     *sets.NewSorted(drv1OutputPath),
+			},
+		})
 		if diff := cmp.Diff(want, info.Info); diff != "" {
 			t.Errorf("info (-want +got):\n%s", diff)
 		}
@@ -669,7 +674,7 @@ func TestRealizeInputReference(t *testing.T) {
 	}
 
 	// Verify that the realizations document that is uploaded is valid.
-	if drv, err := drvObject.ParseDerivation(); err != nil {
+	if drv, err := zbstore.ParseDerivationObject(ctx, drvObject); err != nil {
 		t.Error(err)
 	} else {
 		drvHash, err := drv.SHA256RealizationHash(nil)

--- a/internal/frontend/urls_test.go
+++ b/internal/frontend/urls_test.go
@@ -84,7 +84,7 @@ func TestURLs(t *testing.T) {
 					t.Fatal(err)
 				}
 				objectBase, subpath, _ := strings.Cut(u.Path, "/")
-				objectIndex := slices.IndexFunc(objects, func(obj *storetest.Object) bool {
+				objectIndex := slices.IndexFunc(objects, func(obj *zbstore.Blob) bool {
 					return obj.StorePath == storePaths[objectBase]
 				})
 				if objectIndex == -1 {

--- a/internal/storetest/fakestore.go
+++ b/internal/storetest/fakestore.go
@@ -14,7 +14,6 @@ import (
 	"zb.256lights.llc/pkg/sets"
 	"zb.256lights.llc/pkg/zbstore"
 	"zombiezen.com/go/nix"
-	"zombiezen.com/go/nix/nar"
 )
 
 var _ interface {
@@ -30,13 +29,13 @@ var _ interface {
 // Realizations can be added with [*Store.AddRealization].
 type Store struct {
 	mu           sync.RWMutex
-	objects      map[zbstore.Path]*Object
+	objects      map[zbstore.Path]*zbstore.Blob
 	realizations map[string]map[string][]*zbstore.Realization
 }
 
 // Object implements [zbstore.Store].
 func (store *Store) Object(ctx context.Context, path zbstore.Path) (zbstore.Object, error) {
-	var obj *Object
+	var obj *zbstore.Blob
 	if store != nil {
 		store.mu.RLock()
 		obj = store.objects[path]
@@ -117,56 +116,6 @@ func (store *Store) AddRealization(ref zbstore.RealizationOutputReference, r *zb
 	m[ref.OutputName] = append(m[ref.OutputName], cloneRealization(r))
 }
 
-// Object is an in-memory implementation of the [zbstore.Object] interface.
-type Object struct {
-	NAR     []byte
-	NARHash nix.Hash
-	zbstore.ExportTrailer
-}
-
-// WriteNAR writes obj.NAR to w.
-func (obj *Object) WriteNAR(ctx context.Context, dst io.Writer) error {
-	_, err := dst.Write(obj.NAR)
-	return err
-}
-
-// Info returns converts obj.ExportTrailer to [*zbstore.ObjectInfo].
-func (obj *Object) Info() *zbstore.ObjectInfo {
-	return &zbstore.ObjectInfo{
-		StorePath:      obj.StorePath,
-		NARSize:        int64(len(obj.NAR)),
-		NARHash:        obj.NARHash,
-		References:     obj.References,
-		ContentAddress: obj.ContentAddress,
-	}
-}
-
-// ParseDerivation parses a ".drv" object as a [*zbstore.Derivation].
-func (obj *Object) ParseDerivation() (*zbstore.Derivation, error) {
-	drvName, ok := obj.StorePath.DerivationName()
-	if !ok {
-		return nil, fmt.Errorf("parse derivation: %s is not a %s file", obj.StorePath, zbstore.DerivationExt)
-	}
-	nr := nar.NewReader(bytes.NewReader(obj.NAR))
-	hdr, err := nr.Next()
-	if err != nil {
-		return nil, err
-	}
-	if !hdr.Mode.IsRegular() {
-		return nil, fmt.Errorf("parse %s derivation: not a flat file", drvName)
-	}
-	drvData, err := io.ReadAll(nr)
-	if err != nil {
-		return nil, fmt.Errorf("parse %s derivation: %v", drvName, err)
-	}
-	if _, err := nr.Next(); err == nil {
-		return nil, fmt.Errorf("parse %s derivation: more than a single file (bug in NAR reader?)", drvName)
-	} else if err != io.EOF {
-		return nil, fmt.Errorf("parse %s derivation: %v", drvName, err)
-	}
-	return zbstore.ParseDerivation(obj.StorePath.Dir(), drvName, drvData)
-}
-
 type storeReceiver struct {
 	store  *Store
 	buf    bytes.Buffer
@@ -178,7 +127,7 @@ func (s *storeReceiver) Write(p []byte) (n int, err error) {
 }
 
 func (s *storeReceiver) ReceiveNAR(trailer *zbstore.ExportTrailer) {
-	obj := &Object{
+	obj := &zbstore.Blob{
 		NAR:           s.buf.Bytes(),
 		ExportTrailer: *trailer,
 	}
@@ -190,7 +139,7 @@ func (s *storeReceiver) ReceiveNAR(trailer *zbstore.ExportTrailer) {
 	s.store.mu.Lock()
 	if s.store.objects[obj.StorePath] == nil {
 		if s.store.objects == nil {
-			s.store.objects = make(map[zbstore.Path]*Object)
+			s.store.objects = make(map[zbstore.Path]*zbstore.Blob)
 		}
 		obj.NAR = bytes.Clone(obj.NAR)
 		obj.ExportTrailer = *cloneExportTrailer(&obj.ExportTrailer)

--- a/internal/storetest/txtar.go
+++ b/internal/storetest/txtar.go
@@ -24,8 +24,8 @@ import (
 // TxtarObjects converts the source files and .drv files in a txtar archive to a slice of [*Object],
 // rewriting their paths to the named directory.
 // TxtarObjects also returns a map of file names to store paths.
-func TxtarObjects(dir zbstore.Directory, files []txtar.File) ([]*Object, map[string]zbstore.Path, error) {
-	objects := make([]*Object, 0, len(files))
+func TxtarObjects(dir zbstore.Directory, files []txtar.File) ([]*zbstore.Blob, map[string]zbstore.Path, error) {
+	objects := make([]*zbstore.Blob, 0, len(files))
 	rewrites := make(map[string]zbstore.Path)
 
 	for objectFiles := range groupFilesByObject(files) {
@@ -41,7 +41,7 @@ func TxtarObjects(dir zbstore.Directory, files []txtar.File) ([]*Object, map[str
 			if err != nil {
 				return objects, rewrites, err
 			}
-			obj := &Object{
+			obj := &zbstore.Blob{
 				ExportTrailer: zbstore.ExportTrailer{
 					References:     *refs,
 					ContentAddress: nix.TextContentAddress(nix.NewHash(nix.SHA256, new(sha256.Sum256(data))[:])),
@@ -74,7 +74,7 @@ func TxtarObjects(dir zbstore.Directory, files []txtar.File) ([]*Object, map[str
 			return objects, rewrites, fmt.Errorf("%s: %v", objectFiles[0].Name, err)
 		}
 		// TODO(someday): References.
-		obj := &Object{NAR: buf.Bytes()}
+		obj := &zbstore.Blob{NAR: buf.Bytes()}
 		obj.ContentAddress, _, err = zbstore.SourceSHA256ContentAddress(bytes.NewReader(buf.Bytes()), nil)
 		if err != nil {
 			return objects, rewrites, fmt.Errorf("%s: %v", objectFiles[0].Name, err)

--- a/zbstore/derivation.go
+++ b/zbstore/derivation.go
@@ -5,6 +5,7 @@ package zbstore
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -68,6 +69,42 @@ func ParseDerivation(dir Directory, name string, data []byte) (*Derivation, erro
 		return nil, err
 	}
 	return drv, nil
+}
+
+// ParseDerivationObject loads a ".drv" [Object] into memory
+// and parses it as a [*Derivation].
+func ParseDerivationObject(ctx context.Context, object Object) (*Derivation, error) {
+	drvPath := object.Info().StorePath
+	drvName, ok := drvPath.DerivationName()
+	if !ok {
+		return nil, fmt.Errorf("parse derivation: %s is not a %s file", drvPath, DerivationExt)
+	}
+
+	pr, pw := io.Pipe()
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		err := object.WriteNAR(ctx, pw)
+		pw.CloseWithError(err)
+	}()
+	defer func() {
+		pr.Close()
+		<-writeDone
+	}()
+
+	nr := nar.NewReader(pr)
+	hdr, err := nr.Next()
+	if err != nil {
+		return nil, fmt.Errorf("parse %s derivation: %v", drvName, err)
+	}
+	if !hdr.Mode.IsRegular() {
+		return nil, fmt.Errorf("parse %s derivation: not a flat file", drvName)
+	}
+	drvData := new(bytes.Buffer)
+	if _, err := io.Copy(drvData, nr); err != nil {
+		return nil, fmt.Errorf("parse %s derivation: %v", drvName, err)
+	}
+	return ParseDerivation(drvPath.Dir(), drvName, drvData.Bytes())
 }
 
 // Export marshals the derivation to a NAR containing ATerm format

--- a/zbstore/object.go
+++ b/zbstore/object.go
@@ -22,6 +22,34 @@ type Object interface {
 	Info() *ObjectInfo
 }
 
+// Blob is an in-memory implementation of the [Object] interface.
+type Blob struct {
+	// NAR is the blob's NAR serialization.
+	NAR []byte
+	// NARHash is an optional hash of NAR.
+	NARHash nix.Hash
+	// ExportTrailer is the blob's metadata.
+	// Deriver is ignored.
+	ExportTrailer
+}
+
+// WriteNAR writes blob.NAR to w.
+func (blob *Blob) WriteNAR(ctx context.Context, dst io.Writer) error {
+	_, err := dst.Write(blob.NAR)
+	return err
+}
+
+// Info returns converts blob.ExportTrailer to [*ObjectInfo].
+func (blob *Blob) Info() *ObjectInfo {
+	return &ObjectInfo{
+		StorePath:      blob.StorePath,
+		NARSize:        int64(len(blob.NAR)),
+		NARHash:        blob.NARHash,
+		References:     blob.References,
+		ContentAddress: blob.ContentAddress,
+	}
+}
+
 // VerifyObject returns an error if the store object's content
 // does not match its path or its content address.
 // opts.Digest is ignored: obj.Trailer().StorePath.Digest() will always be used.


### PR DESCRIPTION
Reworked `*storetest.Object.ParseDerivation` into `zbstore.ParseDerivationObject`, a function that operates on any `zbstore.Object`.

Updates #345

<!-- jj-domino -->
<!-- Do not remove this comment! Everything in this section will be rewritten by jj-domino. -->

## Related Pull Requests

This pull request is part of a stack managed by [jj-domino](https://github.com/zombiezen/jj-domino):

 1. *→ this pull request ←*
 2. #354
